### PR TITLE
Add product customization modal

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -1,0 +1,16 @@
+#winshirt-modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.8);z-index:9999;align-items:center;justify-content:center;}
+#winshirt-modal.open{display:flex;}
+#winshirt-modal .winshirt-modal-content{background:#fff;width:90%;max-width:900px;max-height:90%;overflow:auto;padding:20px;position:relative;border-radius:4px;display:flex;flex-direction:column;}
+#winshirt-modal .winshirt-close{position:absolute;top:10px;right:15px;font-size:24px;cursor:pointer;}
+.winshirt-tab-links{list-style:none;padding:0;margin:0 0 10px;display:flex;flex-wrap:wrap;}
+.winshirt-tab-links li{margin-right:5px;}
+.winshirt-tab-links li a{display:block;padding:8px 12px;background:#eee;text-decoration:none;color:#000;border-radius:3px;}
+.winshirt-tab-links li.active a{background:#ddd;}
+.winshirt-tab{display:none;}
+.winshirt-tab.active{display:block;}
+.winshirt-upload{float:right;}
+.winshirt-preview{text-align:center;margin-top:20px;}
+.winshirt-preview img{max-width:250px;}
+.winshirt-preview-buttons{text-align:center;margin-bottom:10px;}
+@media(max-width:600px){#winshirt-modal .winshirt-modal-content{width:100%;height:100%;max-height:100%;border-radius:0;}}
+.winshirt-text{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);font-size:24px;color:#000;}

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -1,0 +1,87 @@
+jQuery(function($){
+    var state = JSON.parse(localStorage.getItem('winshirt_state')) || {front:'', back:'', text:'', side:'front'};
+
+    function saveState(){
+        localStorage.setItem('winshirt_state', JSON.stringify(state));
+    }
+
+    function loadState(){
+        if(state.front){
+            $('#winshirt-preview-front img').attr('src', state.front);
+        }
+        if(state.back){
+            $('#winshirt-preview-back img').attr('src', state.back);
+        }
+        if(state.text){
+            $('#winshirt-text-input').val(state.text);
+            $('.winshirt-text').text(state.text);
+        }
+        switchSide(state.side || 'front');
+    }
+
+    function switchSide(side){
+        state.side = side;
+        $('#winshirt-preview-front, #winshirt-preview-back').hide();
+        if(side === 'back'){
+            $('#winshirt-preview-back').show();
+        }else{
+            $('#winshirt-preview-front').show();
+        }
+        saveState();
+    }
+
+    $(document).on('click', '#winshirt-open-modal', function(e){
+        e.preventDefault();
+        $('#winshirt-modal').addClass('open');
+    });
+
+    $(document).on('click', '.winshirt-close', function(){
+        $('#winshirt-modal').removeClass('open');
+    });
+
+    $(document).on('click', '.winshirt-tab-links a', function(e){
+        e.preventDefault();
+        var target = $(this).attr('href');
+        $('.winshirt-tab-links li').removeClass('active');
+        $(this).parent().addClass('active');
+        $('.winshirt-tab').removeClass('active');
+        $(target).addClass('active');
+    });
+
+    $(document).on('click', '.winshirt-upload', function(){
+        $(this).next('input[type=file]').trigger('click');
+    });
+
+    $(document).on('change', '.winshirt-upload-input', function(){
+        var side = state.side;
+        var input = this;
+        if(!input.files.length) return;
+        var reader = new FileReader();
+        reader.onload = function(e){
+            if(side === 'back'){
+                $('#winshirt-preview-back img').attr('src', e.target.result);
+                state.back = e.target.result;
+            } else {
+                $('#winshirt-preview-front img').attr('src', e.target.result);
+                state.front = e.target.result;
+            }
+            saveState();
+        };
+        reader.readAsDataURL(input.files[0]);
+    });
+
+    $(document).on('input', '#winshirt-text-input', function(){
+        state.text = $(this).val();
+        $('.winshirt-text').text(state.text);
+        saveState();
+    });
+
+    $(document).on('click', '#winshirt-front-btn', function(){
+        switchSide('front');
+    });
+    $(document).on('click', '#winshirt-back-btn', function(){
+        switchSide('back');
+    });
+
+    loadState();
+});

--- a/includes/init.php
+++ b/includes/init.php
@@ -7,3 +7,17 @@ add_action('admin_menu', function () {
 function winshirt_admin_page() {
     echo '<div class="wrap"><h1>WinShirt - Dashboard</h1><p>Bienvenue sur le back-office WinShirt.</p></div>';
 }
+
+// Enqueue assets on product pages
+add_action('wp_enqueue_scripts', function () {
+    if (is_product()) {
+        wp_enqueue_style('winshirt-modal', WINSHIRT_URL . 'assets/css/winshirt-modal.css', [], '1.0');
+        wp_enqueue_script('winshirt-modal', WINSHIRT_URL . 'assets/js/winshirt-modal.js', ['jquery'], '1.0', true);
+    }
+});
+
+// Add customize button and modal on product page
+add_action('woocommerce_after_add_to_cart_form', function () {
+    echo '<button id="winshirt-open-modal" class="button">' . esc_html__('Personnaliser ce produit', 'winshirt') . '</button>';
+    include WINSHIRT_PATH . 'templates/modal-personnalisation.php';
+});

--- a/templates/modal-personnalisation.php
+++ b/templates/modal-personnalisation.php
@@ -1,0 +1,45 @@
+<div id="winshirt-modal" class="winshirt-modal">
+  <div class="winshirt-modal-content">
+    <span class="winshirt-close">&times;</span>
+    <ul class="winshirt-tab-links">
+      <li class="active"><a href="#winshirt-tab-galerie">🖼 Galerie</a></li>
+      <li><a href="#winshirt-tab-texte">🔤 Texte</a></li>
+      <li><a href="#winshirt-tab-ia">🤖 IA</a></li>
+      <li><a href="#winshirt-tab-svg">🖌️ SVG</a></li>
+    </ul>
+    <div class="winshirt-tab" id="winshirt-tab-galerie">
+      <button class="winshirt-upload button">Uploader un visuel</button>
+      <input type="file" class="winshirt-upload-input" style="display:none" accept="image/*" />
+      <p>Choisissez un design dans la galerie.</p>
+    </div>
+    <div class="winshirt-tab" id="winshirt-tab-texte">
+      <button class="winshirt-upload button">Uploader un visuel</button>
+      <input type="file" class="winshirt-upload-input" style="display:none" accept="image/*" />
+      <textarea id="winshirt-text-input" rows="3" style="width:100%;" placeholder="Votre texte..."></textarea>
+    </div>
+    <div class="winshirt-tab" id="winshirt-tab-ia">
+      <button class="winshirt-upload button">Uploader un visuel</button>
+      <input type="file" class="winshirt-upload-input" style="display:none" accept="image/*" />
+      <p>Générez une image grâce à l'IA (bientôt disponible).</p>
+    </div>
+    <div class="winshirt-tab" id="winshirt-tab-svg">
+      <button class="winshirt-upload button">Uploader un visuel</button>
+      <input type="file" class="winshirt-upload-input" style="display:none" accept="image/*" />
+      <p>Bibliothèque d'icônes vectorielles.</p>
+    </div>
+    <div class="winshirt-preview-buttons">
+      <button id="winshirt-front-btn" class="button">Recto</button>
+      <button id="winshirt-back-btn" class="button">Verso</button>
+    </div>
+    <div class="winshirt-preview">
+      <div id="winshirt-preview-front" style="display:none;position:relative;">
+        <img src="" alt="Preview front" />
+        <span class="winshirt-text"></span>
+      </div>
+      <div id="winshirt-preview-back" style="display:none;position:relative;">
+        <img src="" alt="Preview back" />
+        <span class="winshirt-text"></span>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add JS and CSS for a customization modal
- show modal on product pages with WooCommerce hooks
- include modal template with several tabs and a front/back preview

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685002b5510883298c1e93dea6bd008c