### PR TITLE
Add custom icon to admin menu

### DIFF
--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 20 20">
+  <rect width="20" height="20" rx="3" fill="#ffffff"/>
+  <path d="M4 5 L6 15 L9 10 L12 15 L14 5" stroke="#000" stroke-width="2" fill="none"/>
+</svg>

--- a/includes/init.php
+++ b/includes/init.php
@@ -1,7 +1,12 @@
 <?php
 // Hook de démarrage
 add_action('admin_menu', function () {
-    add_menu_page('WinShirt', 'WinShirt', 'manage_options', 'winshirt', 'winshirt_admin_page', 'dashicons-tshirt', 56);
+    $icon_path = WINSHIRT_PATH . 'assets/logo.svg';
+    $icon_data_uri = 'dashicons-tshirt';
+    if (file_exists($icon_path)) {
+        $icon_data_uri = 'data:image/svg+xml;base64,' . base64_encode(file_get_contents($icon_path));
+    }
+    add_menu_page('WinShirt', 'WinShirt', 'manage_options', 'winshirt', 'winshirt_admin_page', $icon_data_uri, 56);
 });
 
 function winshirt_admin_page() {


### PR DESCRIPTION
## Summary
- add svg logo asset
- use base64 data URI for admin menu icon

## Testing
- `php -l includes/init.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68504a7d278c8329b2e989feb71612bc