### PR TITLE
Add product management interface

### DIFF
--- a/includes/pages/produits.php
+++ b/includes/pages/produits.php
@@ -2,7 +2,25 @@
 defined('ABSPATH') || exit;
 
 function winshirt_page_products() {
-    echo '<div class="wrap"><h1>Produits personnalisables</h1>';
+    if (isset($_POST['winshirt_product_nonce']) && wp_verify_nonce($_POST['winshirt_product_nonce'], 'save_winshirt_product_meta')) {
+        $product_id = absint($_POST['product_id']);
+
+        update_post_meta($product_id, '_winshirt_mockups', sanitize_text_field($_POST['winshirt_mockups'] ?? ''));
+        update_post_meta($product_id, '_winshirt_visuals', sanitize_text_field($_POST['winshirt_visuals'] ?? ''));
+        update_post_meta($product_id, '_winshirt_lottery', sanitize_text_field($_POST['winshirt_lottery'] ?? ''));
+        update_post_meta($product_id, '_winshirt_enabled', isset($_POST['winshirt_enabled']) ? 'yes' : 'no');
+
+        echo '<div class="updated"><p>' . esc_html__('Metadonnees enregistrees.', 'winshirt') . '</p></div>';
+    }
+
+    $search   = isset($_GET['s']) ? sanitize_text_field(wp_unslash($_GET['s'])) : '';
+    $products = wc_get_products([
+        'search' => $search,
+        'limit'  => -1,
+        'status' => 'publish',
+    ]);
+
+    echo '<div class="wrap"><h1>' . esc_html__('Produits', 'winshirt') . '</h1>';
     include WINSHIRT_PATH . 'templates/admin/partials/produits-list.php';
     echo '</div>';
 }

--- a/readme.txt
+++ b/readme.txt
@@ -8,5 +8,8 @@ License: GPLv2 or later
 
 Plugin pour personnalisation de produits et loteries via WooCommerce.
 
+## Gestion des produits
+Une page "Produits" est disponible dans le menu WinShirt pour associer des mockups, visuels et loteries aux produits WooCommerce.
+
 ## Personnalisation de produits
 Un bouton "Personnaliser ce produit" ouvre un modale sur la fiche produit pour choisir un design, saisir du texte ou importer une image. Les sélections sont temporairement sauvegardées via localStorage.

--- a/templates/admin/partials/produits-list.php
+++ b/templates/admin/partials/produits-list.php
@@ -1,1 +1,51 @@
-<p>Liste des produits personnalisables à venir.</p>
+<?php
+/**
+ * Admin product list for WinShirt.
+ */
+?>
+<form method="get" style="margin-bottom:15px;">
+    <input type="hidden" name="page" value="winshirt-products" />
+    <input type="search" name="s" value="<?php echo esc_attr( $search ); ?>" placeholder="<?php esc_attr_e( 'Rechercher un produit', 'winshirt' ); ?>" />
+    <input type="submit" class="button" value="<?php esc_attr_e( 'Rechercher', 'winshirt' ); ?>" />
+</form>
+<table class="widefat fixed">
+    <thead>
+        <tr>
+            <th><?php esc_html_e( 'Produit', 'winshirt' ); ?></th>
+            <th><?php esc_html_e( 'Mockups', 'winshirt' ); ?></th>
+            <th><?php esc_html_e( 'Visuels', 'winshirt' ); ?></th>
+            <th><?php esc_html_e( 'Loterie', 'winshirt' ); ?></th>
+            <th><?php esc_html_e( 'Personnalisation', 'winshirt' ); ?></th>
+            <th><?php esc_html_e( 'Action', 'winshirt' ); ?></th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php if ( $products ) : ?>
+        <?php foreach ( $products as $product ) : ?>
+            <?php
+                $pid     = $product->get_id();
+                $mockups = get_post_meta( $pid, '_winshirt_mockups', true );
+                $visuals = get_post_meta( $pid, '_winshirt_visuals', true );
+                $lottery = get_post_meta( $pid, '_winshirt_lottery', true );
+                $enabled = get_post_meta( $pid, '_winshirt_enabled', true ) === 'yes';
+            ?>
+            <tr>
+                <td><?php echo esc_html( $product->get_name() ); ?></td>
+                <td><input type="text" name="winshirt_mockups" value="<?php echo esc_attr( $mockups ); ?>" form="winshirt-form-<?php echo esc_attr( $pid ); ?>" /></td>
+                <td><input type="text" name="winshirt_visuals" value="<?php echo esc_attr( $visuals ); ?>" form="winshirt-form-<?php echo esc_attr( $pid ); ?>" /></td>
+                <td><input type="text" name="winshirt_lottery" value="<?php echo esc_attr( $lottery ); ?>" form="winshirt-form-<?php echo esc_attr( $pid ); ?>" /></td>
+                <td style="text-align:center;"><input type="checkbox" name="winshirt_enabled" value="1" <?php checked( $enabled ); ?> form="winshirt-form-<?php echo esc_attr( $pid ); ?>" /></td>
+                <td>
+                    <form method="post" id="winshirt-form-<?php echo esc_attr( $pid ); ?>">
+                        <?php wp_nonce_field( 'save_winshirt_product_meta', 'winshirt_product_nonce' ); ?>
+                        <input type="hidden" name="product_id" value="<?php echo esc_attr( $pid ); ?>" />
+                        <input type="submit" class="button button-primary" value="<?php esc_attr_e( 'Enregistrer', 'winshirt' ); ?>" />
+                    </form>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+    <?php else : ?>
+        <tr><td colspan="6"><?php esc_html_e( 'Aucun produit trouve.', 'winshirt' ); ?></td></tr>
+    <?php endif; ?>
+    </tbody>
+</table>

--- a/winshirt.php
+++ b/winshirt.php
@@ -14,6 +14,7 @@ define('WINSHIRT_URL', plugin_dir_url(__FILE__));
 require_once WINSHIRT_PATH . 'includes/init.php';
 require_once WINSHIRT_PATH . 'includes/pages/mockups.php';
 require_once WINSHIRT_PATH . 'includes/pages/visuels.php';
+require_once WINSHIRT_PATH . 'includes/pages/produits.php';
 require_once WINSHIRT_PATH . 'includes/pages/loteries.php';
 require_once WINSHIRT_PATH . 'includes/pages/commandes.php';
 require_once WINSHIRT_PATH . 'includes/pages/configuration.php';
@@ -67,6 +68,15 @@ function winshirt_register_admin_pages() {
         'manage_options',
         'winshirt-designs',
         'winshirt_page_designs'
+    );
+
+    add_submenu_page(
+        'winshirt-dashboard',
+        'Produits',
+        'Produits',
+        'manage_options',
+        'winshirt-products',
+        'winshirt_page_products'
     );
 
     add_submenu_page(


### PR DESCRIPTION
## Summary
- integrate a new "Produits" submenu
- add admin page to list WooCommerce products
- allow editing WinShirt metadata per product
- document the new feature

## Testing
- `php` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68511955aa548329aff0563d8c54422e