### PR TITLE
Add WinShirt dashboard page

### DIFF
--- a/templates/admin/partials/dashboard.php
+++ b/templates/admin/partials/dashboard.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Admin dashboard for WinShirt.
+ * Variables expected: $mockup_count, $visual_count, $product_count, $lottery_count, $lottery_progress
+ */
+?>
+<h1><?php esc_html_e('Bienvenue sur le tableau de bord WinShirt', 'winshirt'); ?></h1>
+<div class="winshirt-dashboard-cards" style="display:flex;flex-wrap:wrap;gap:20px;margin-top:20px;">
+  <div class="winshirt-dashboard-card" style="flex:1;min-width:150px;padding:20px;background:#fff;border:1px solid #ddd;border-radius:8px;text-align:center;">
+    <h2 style="margin:0;font-size:2em;"><?php echo esc_html($mockup_count); ?></h2>
+    <p style="margin:5px 0 0;">Mockups</p>
+  </div>
+  <div class="winshirt-dashboard-card" style="flex:1;min-width:150px;padding:20px;background:#fff;border:1px solid #ddd;border-radius:8px;text-align:center;">
+    <h2 style="margin:0;font-size:2em;"><?php echo esc_html($visual_count); ?></h2>
+    <p style="margin:5px 0 0;">Visuels</p>
+  </div>
+  <div class="winshirt-dashboard-card" style="flex:1;min-width:150px;padding:20px;background:#fff;border:1px solid #ddd;border-radius:8px;text-align:center;">
+    <h2 style="margin:0;font-size:2em;"><?php echo esc_html($product_count); ?></h2>
+    <p style="margin:5px 0 0;">Produits personnalisables</p>
+  </div>
+  <div class="winshirt-dashboard-card" style="flex:1;min-width:150px;padding:20px;background:#fff;border:1px solid #ddd;border-radius:8px;text-align:center;">
+    <h2 style="margin:0;font-size:2em;"><?php echo esc_html($lottery_count); ?></h2>
+    <p style="margin:5px 0 0;">Loteries</p>
+  </div>
+</div>
+
+<div class="winshirt-dashboard-progress" style="margin-top:30px;max-width:400px;">
+  <h3 style="margin-bottom:10px;">Participation aux loteries</h3>
+  <div style="background:#eee;border-radius:4px;height:20px;position:relative;">
+    <div style="background:#4caf50;height:100%;width:<?php echo esc_attr($lottery_progress); ?>%;border-radius:4px;"></div>
+  </div>
+  <p style="margin-top:5px;"><?php echo esc_html(round($lottery_progress)); ?>% des produits contiennent une loterie.</p>
+</div>
+
+<div class="winshirt-dashboard-links" style="margin-top:30px;">
+  <h3>Liens rapides</h3>
+  <ul style="list-style:disc;padding-left:20px;">
+    <li><a href="<?php echo esc_url(admin_url('admin.php?page=winshirt-mockups')); ?>">Ajouter un mockup</a></li>
+    <li><a href="<?php echo esc_url(admin_url('admin.php?page=winshirt-designs')); ?>">Voir les visuels</a></li>
+    <li><a href="<?php echo esc_url(admin_url('admin.php?page=winshirt-products')); ?>">Configurer les produits</a></li>
+    <li><a href="<?php echo esc_url(admin_url('admin.php?page=winshirt-lotteries')); ?>">Gérer les loteries</a></li>
+    <li><a href="<?php echo esc_url(admin_url('admin.php?page=winshirt-settings')); ?>">Paramètres du plugin</a></li>
+  </ul>
+</div>

--- a/winshirt.php
+++ b/winshirt.php
@@ -111,5 +111,48 @@ function winshirt_register_admin_pages() {
  * Display the dashboard page.
  */
 function winshirt_page_dashboard() {
-    echo '<div class="wrap"><h1>Bienvenue sur le tableau de bord WinShirt. Interface à venir.</h1></div>';
+    // Gather counts based on product metadata
+    $products          = wc_get_products(['limit' => -1, 'status' => 'publish']);
+    $mockup_ids        = [];
+    $visual_ids        = [];
+    $lotteries         = [];
+    $product_count     = 0;
+    $lottery_products  = 0;
+
+    foreach ($products as $product) {
+        $pid     = $product->get_id();
+        $mockups = get_post_meta($pid, '_winshirt_mockups', true);
+        $visuals = get_post_meta($pid, '_winshirt_visuals', true);
+        $lottery = get_post_meta($pid, '_winshirt_lottery', true);
+        $enabled = get_post_meta($pid, '_winshirt_enabled', true) === 'yes';
+
+        if ($enabled) {
+            $product_count++;
+        }
+
+        if ($mockups) {
+            $ids        = array_filter(array_map('trim', explode(',', $mockups)));
+            $mockup_ids = array_merge($mockup_ids, $ids);
+        }
+
+        if ($visuals) {
+            $ids        = array_filter(array_map('trim', explode(',', $visuals)));
+            $visual_ids = array_merge($visual_ids, $ids);
+        }
+
+        if ($lottery) {
+            $lotteries[] = $lottery;
+            $lottery_products++;
+        }
+    }
+
+    $mockup_count   = count(array_unique($mockup_ids));
+    $visual_count   = count(array_unique($visual_ids));
+    $lottery_count  = count(array_unique($lotteries));
+    $total_products = count($products);
+    $lottery_progress = $total_products > 0 ? ($lottery_products / $total_products) * 100 : 0;
+
+    echo '<div class="wrap">';
+    include WINSHIRT_PATH . 'templates/admin/partials/dashboard.php';
+    echo '</div>';
 }


### PR DESCRIPTION
## Summary
- implement dashboard counts and layout
- add new dashboard template with summary cards, progress bar and quick links

## Testing
- `php -l winshirt.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68511d7dd9008329b77e30ea528723a8