### PR TITLE
Add mockup admin interface

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -23,3 +23,13 @@ function winshirt_render_customize_button() {
     include WINSHIRT_PATH . 'templates/frontend/modal-personnalisation.php';
 }
 add_action('woocommerce_single_product_summary', 'winshirt_render_customize_button', 35);
+
+// Register custom post type for mockups
+add_action('init', function () {
+    register_post_type('winshirt_mockup', [
+        'label'       => 'Mockups',
+        'public'      => false,
+        'show_ui'     => false,
+        'supports'    => ['title', 'thumbnail'],
+    ]);
+});

--- a/includes/pages/mockups.php
+++ b/includes/pages/mockups.php
@@ -2,7 +2,68 @@
 defined('ABSPATH') || exit;
 
 function winshirt_page_mockups() {
-    echo '<div class="wrap"><h1>Gestion des mockups</h1>';
+    $editing = null;
+
+    // Handle deletion
+    if (isset($_GET['delete']) && isset($_GET['_wpnonce']) && wp_verify_nonce($_GET['_wpnonce'], 'delete_mockup_' . absint($_GET['delete']))) {
+        wp_delete_post(absint($_GET['delete']), true);
+        echo '<div class="updated"><p>' . esc_html__('Mockup supprime.', 'winshirt') . '</p></div>';
+    }
+
+    // Handle edit request
+    if (isset($_GET['edit'])) {
+        $editing = get_post(absint($_GET['edit']));
+    }
+
+    // Handle form submission
+    if (isset($_POST['winshirt_mockup_nonce']) && wp_verify_nonce($_POST['winshirt_mockup_nonce'], 'save_winshirt_mockup')) {
+        $mockup_id = isset($_POST['mockup_id']) ? absint($_POST['mockup_id']) : 0;
+
+        $data = [
+            'post_type'   => 'winshirt_mockup',
+            'post_title'  => sanitize_text_field($_POST['title'] ?? ''),
+            'post_status' => 'publish',
+        ];
+
+        if ($mockup_id) {
+            $data['ID'] = $mockup_id;
+            wp_update_post($data);
+        } else {
+            $mockup_id = wp_insert_post($data);
+        }
+
+        update_post_meta($mockup_id, '_winshirt_product_type', sanitize_text_field($_POST['product_type'] ?? ''));
+        update_post_meta($mockup_id, '_winshirt_side', in_array($_POST['side'] ?? 'front', ['front', 'back'], true) ? $_POST['side'] : 'front');
+        update_post_meta($mockup_id, '_winshirt_format', sanitize_text_field($_POST['format'] ?? ''));
+
+        $area = [
+            'x' => floatval($_POST['area_x'] ?? 0),
+            'y' => floatval($_POST['area_y'] ?? 0),
+            'w' => floatval($_POST['area_w'] ?? 0),
+            'h' => floatval($_POST['area_h'] ?? 0),
+        ];
+        update_post_meta($mockup_id, '_winshirt_area', $area);
+
+        $families = isset($_POST['families']) ? array_map('intval', (array) $_POST['families']) : [];
+        update_post_meta($mockup_id, '_winshirt_families', $families);
+
+        if (!empty($_FILES['image']['tmp_name'])) {
+            require_once ABSPATH . 'wp-admin/includes/file.php';
+            require_once ABSPATH . 'wp-admin/includes/image.php';
+            $attachment_id = media_handle_upload('image', 0);
+            if (!is_wp_error($attachment_id)) {
+                set_post_thumbnail($mockup_id, $attachment_id);
+            }
+        }
+
+        echo '<div class="updated"><p>' . esc_html__('Mockup enregistre.', 'winshirt') . '</p></div>';
+        $editing = get_post($mockup_id);
+    }
+
+    $mockups    = get_posts(['post_type' => 'winshirt_mockup', 'numberposts' => -1, 'orderby' => 'title']);
+    $categories = get_terms(['taxonomy' => 'product_cat', 'hide_empty' => false]);
+
+    echo '<div class="wrap"><h1>' . esc_html__('Gestion des mockups', 'winshirt') . '</h1>';
     include WINSHIRT_PATH . 'templates/admin/partials/mockups-list.php';
     echo '</div>';
 }

--- a/templates/admin/partials/mockups-list.php
+++ b/templates/admin/partials/mockups-list.php
@@ -1,1 +1,122 @@
-<p>Liste des mockups à venir.</p>
+<?php
+/**
+ * Admin mockup management interface.
+ * Variables: $mockups, $editing, $categories
+ */
+?>
+<h2><?php esc_html_e('Liste des mockups', 'winshirt'); ?></h2>
+<table class="widefat fixed">
+    <thead>
+        <tr>
+            <th><?php esc_html_e('Titre', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Type', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Recto/Verso', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Format', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Aperçu', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Actions', 'winshirt'); ?></th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php if ($mockups) : ?>
+        <?php foreach ($mockups as $mockup) : ?>
+            <?php
+                $type   = get_post_meta($mockup->ID, '_winshirt_product_type', true);
+                $side   = get_post_meta($mockup->ID, '_winshirt_side', true);
+                $format = get_post_meta($mockup->ID, '_winshirt_format', true);
+            ?>
+            <tr>
+                <td><?php echo esc_html($mockup->post_title); ?></td>
+                <td><?php echo esc_html($type); ?></td>
+                <td><?php echo esc_html($side === 'back' ? 'Verso' : 'Recto'); ?></td>
+                <td><?php echo esc_html($format); ?></td>
+                <td><?php echo get_the_post_thumbnail($mockup->ID, 'thumbnail'); ?></td>
+                <td>
+                    <a class="button" href="<?php echo esc_url(add_query_arg(['page' => 'winshirt-mockups', 'edit' => $mockup->ID], admin_url('admin.php'))); ?>"><?php esc_html_e('Modifier', 'winshirt'); ?></a>
+                    <a class="button delete" href="<?php echo esc_url(wp_nonce_url(add_query_arg(['page' => 'winshirt-mockups', 'delete' => $mockup->ID], admin_url('admin.php')), 'delete_mockup_' . $mockup->ID)); ?>"><?php esc_html_e('Supprimer', 'winshirt'); ?></a>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+    <?php else : ?>
+        <tr><td colspan="6"><?php esc_html_e('Aucun mockup', 'winshirt'); ?></td></tr>
+    <?php endif; ?>
+    </tbody>
+</table>
+
+<hr/>
+
+<h2><?php echo $editing ? esc_html__('Modifier le mockup', 'winshirt') : esc_html__('Ajouter un mockup', 'winshirt'); ?></h2>
+<form method="post" enctype="multipart/form-data">
+    <?php wp_nonce_field('save_winshirt_mockup', 'winshirt_mockup_nonce'); ?>
+    <input type="hidden" name="mockup_id" value="<?php echo esc_attr($editing->ID ?? 0); ?>" />
+    <table class="form-table">
+        <tr>
+            <th scope="row"><label for="mockup-title">Titre</label></th>
+            <td><input name="title" id="mockup-title" type="text" class="regular-text" value="<?php echo esc_attr($editing->post_title ?? ''); ?>" required /></td>
+        </tr>
+        <tr>
+            <th scope="row">Image</th>
+            <td>
+                <input type="file" name="image" />
+                <?php if ($editing && has_post_thumbnail($editing->ID)) { echo get_the_post_thumbnail($editing->ID, 'thumbnail'); } ?>
+            </td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="product-type">Type de produit</label></th>
+            <td>
+                <select name="product_type" id="product-type">
+                    <?php $types = ['T-Shirt','Polo','Casquette','Sweat'];
+                    $current_type = $editing ? get_post_meta($editing->ID, '_winshirt_product_type', true) : '';
+                    foreach ($types as $t) {
+                        echo '<option value="' . esc_attr($t) . '" ' . selected($current_type, $t, false) . '>' . esc_html($t) . '</option>';
+                    } ?>
+                </select>
+            </td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="format">Format impression</label></th>
+            <td>
+                <select name="format" id="format">
+                    <?php $formats = ['A3','A4','A5','A6','A7'];
+                    $current_format = $editing ? get_post_meta($editing->ID, '_winshirt_format', true) : '';
+                    foreach ($formats as $f) {
+                        echo '<option value="' . esc_attr($f) . '" ' . selected($current_format, $f, false) . '>' . esc_html($f) . '</option>';
+                    } ?>
+                </select>
+            </td>
+        </tr>
+        <tr>
+            <th scope="row">Recto/Verso</th>
+            <td>
+                <?php $current_side = $editing ? get_post_meta($editing->ID, '_winshirt_side', true) : 'front'; ?>
+                <label><input type="radio" name="side" value="front" <?php checked($current_side, 'front'); ?> /> <?php esc_html_e('Recto', 'winshirt'); ?></label>
+                <label style="margin-left:10px;"><input type="radio" name="side" value="back" <?php checked($current_side, 'back'); ?> /> <?php esc_html_e('Verso', 'winshirt'); ?></label>
+            </td>
+        </tr>
+        <?php $area = $editing ? get_post_meta($editing->ID, '_winshirt_area', true) : ['x'=>'','y'=>'','w'=>'','h'=>''];
+              $area = is_array($area) ? $area : ['x'=>'','y'=>'','w'=>'','h'=>'']; ?>
+        <tr>
+            <th scope="row">Zone d'impression</th>
+            <td>
+                X <input type="number" step="0.01" name="area_x" value="<?php echo esc_attr($area['x']); ?>" style="width:70px;" />
+                Y <input type="number" step="0.01" name="area_y" value="<?php echo esc_attr($area['y']); ?>" style="width:70px;" />
+                <?php esc_html_e('Largeur', 'winshirt'); ?> <input type="number" step="0.01" name="area_w" value="<?php echo esc_attr($area['w']); ?>" style="width:70px;" />
+                <?php esc_html_e('Hauteur', 'winshirt'); ?> <input type="number" step="0.01" name="area_h" value="<?php echo esc_attr($area['h']); ?>" style="width:70px;" />
+            </td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="families">Familles de produits</label></th>
+            <td>
+                <?php $current_families = $editing ? get_post_meta($editing->ID, '_winshirt_families', true) : [];
+                $current_families = is_array($current_families) ? $current_families : []; ?>
+                <select name="families[]" id="families" multiple size="5">
+                    <?php foreach ($categories as $cat) {
+                        echo '<option value="' . esc_attr($cat->term_id) . '" ' . selected(in_array($cat->term_id, $current_families), true, false) . '>' . esc_html($cat->name) . '</option>';
+                    } ?>
+                </select>
+            </td>
+        </tr>
+    </table>
+    <p>
+        <input type="submit" class="button button-primary" value="<?php echo $editing ? esc_attr__('Mettre à jour', 'winshirt') : esc_attr__('Ajouter mockup', 'winshirt'); ?>" />
+    </p>
+</form>


### PR DESCRIPTION
## Summary
- register a custom post type for mockups
- implement full mockup management page
- render list and form in template

## Testing
- `php -l includes/init.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68511e9f84c48329bab0a17ef893e4f9