### PR TITLE
Add visual management admin interface

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -9,6 +9,23 @@ add_action('wp_enqueue_scripts', function () {
     }
 });
 
+// Register custom post type for visuals
+add_action('init', function () {
+    register_post_type('winshirt_visual', [
+        'label'       => 'Visuels',
+        'public'      => false,
+        'show_ui'     => false,
+        'supports'    => ['title', 'thumbnail'],
+    ]);
+});
+
+// Register FTP options
+add_action('admin_init', function () {
+    register_setting('winshirt_options', 'winshirt_ftp_host');
+    register_setting('winshirt_options', 'winshirt_ftp_user');
+    register_setting('winshirt_options', 'winshirt_ftp_pass');
+});
+
 // Enqueue assets on WinShirt admin pages
 add_action('admin_enqueue_scripts', function ($hook) {
     if (strpos($hook, 'winshirt') !== false) {

--- a/includes/pages/visuels.php
+++ b/includes/pages/visuels.php
@@ -1,7 +1,104 @@
 <?php
 defined('ABSPATH') || exit;
 
+/**
+ * Upload the given file to the configured FTP server.
+ */
+function winshirt_send_to_ftp($file_path) {
+    $host = get_option('winshirt_ftp_host');
+    $user = get_option('winshirt_ftp_user');
+    $pass = get_option('winshirt_ftp_pass');
+
+    if (!$host || !$user || !$pass) {
+        return;
+    }
+
+    $conn = @ftp_connect($host);
+    if ($conn && @ftp_login($conn, $user, $pass)) {
+        ftp_pasv($conn, true);
+        $remote = basename($file_path);
+        @ftp_put($conn, $remote, $file_path, FTP_BINARY);
+        ftp_close($conn);
+    }
+}
+
 function winshirt_page_designs() {
+    $types   = ['Galerie', 'IA', 'Upload', 'SVG'];
+    $filters = [
+        'type' => sanitize_text_field($_GET['type'] ?? ''),
+        'date' => sanitize_text_field($_GET['date'] ?? ''),
+    ];
+
+    // Handle single deletion
+    if (isset($_GET['delete']) && isset($_GET['_wpnonce']) && wp_verify_nonce($_GET['_wpnonce'], 'delete_visual_' . absint($_GET['delete']))) {
+        wp_delete_post(absint($_GET['delete']), true);
+        echo '<div class="updated"><p>' . esc_html__('Visuel supprimé.', 'winshirt') . '</p></div>';
+    }
+
+    // Handle validation
+    if (isset($_GET['validate']) && isset($_GET['_wpnonce']) && wp_verify_nonce($_GET['_wpnonce'], 'validate_visual_' . absint($_GET['validate']))) {
+        update_post_meta(absint($_GET['validate']), '_winshirt_visual_validated', 'yes');
+        echo '<div class="updated"><p>' . esc_html__('Visuel validé.', 'winshirt') . '</p></div>';
+    }
+
+    // Handle bulk deletion
+    if (isset($_POST['winshirt_bulk_nonce']) && wp_verify_nonce($_POST['winshirt_bulk_nonce'], 'winshirt_bulk_action')) {
+        if (!empty($_POST['selected']) && $_POST['bulk_action'] === 'delete') {
+            foreach ((array) $_POST['selected'] as $vid) {
+                wp_delete_post(absint($vid), true);
+            }
+            echo '<div class="updated"><p>' . esc_html__('Visuels supprimés.', 'winshirt') . '</p></div>';
+        }
+    }
+
+    // Handle add form
+    if (isset($_POST['winshirt_visual_nonce']) && wp_verify_nonce($_POST['winshirt_visual_nonce'], 'winshirt_add_visual')) {
+        require_once ABSPATH . 'wp-admin/includes/file.php';
+        require_once ABSPATH . 'wp-admin/includes/image.php';
+        $attachment_id = media_handle_upload('file', 0);
+        if (!is_wp_error($attachment_id)) {
+            $post_id = wp_insert_post([
+                'post_type'   => 'winshirt_visual',
+                'post_title'  => sanitize_text_field($_POST['title'] ?? ''),
+                'post_status' => 'publish',
+            ]);
+            if ($post_id) {
+                set_post_thumbnail($post_id, $attachment_id);
+                update_post_meta($post_id, '_winshirt_visual_type', sanitize_text_field($_POST['type'] ?? ''));
+                update_post_meta($post_id, '_winshirt_visual_validated', 'no');
+                $path = get_attached_file($attachment_id);
+                winshirt_send_to_ftp($path);
+                echo '<div class="updated"><p>' . esc_html__('Visuel ajouté.', 'winshirt') . '</p></div>';
+            }
+        } else {
+            echo '<div class="error"><p>' . esc_html__('Erreur lors de l\'upload.', 'winshirt') . '</p></div>';
+        }
+    }
+
+    $query = [
+        'post_type'   => 'winshirt_visual',
+        'numberposts' => -1,
+        'orderby'     => 'date',
+        'order'       => 'DESC',
+    ];
+
+    if ($filters['type']) {
+        $query['meta_query'][] = [
+            'key'   => '_winshirt_visual_type',
+            'value' => $filters['type'],
+        ];
+    }
+
+    if ($filters['date']) {
+        $query['date_query'][] = [
+            'after'     => $filters['date'],
+            'before'    => $filters['date'] . ' 23:59:59',
+            'inclusive' => true,
+        ];
+    }
+
+    $visuals = get_posts($query);
+
     echo '<div class="wrap"><h1>Bibliothèque des visuels</h1>';
     include WINSHIRT_PATH . 'templates/admin/partials/visuels-list.php';
     echo '</div>';

--- a/readme.txt
+++ b/readme.txt
@@ -11,5 +11,8 @@ Plugin pour personnalisation de produits et loteries via WooCommerce.
 ## Gestion des produits
 Une page "Produits" est disponible dans le menu WinShirt pour associer des mockups, visuels et loteries aux produits WooCommerce.
 
+## Gestion des visuels
+L'onglet "Visuels" permet d'importer ou supprimer des images. Les visuels peuvent être filtrés par type ou date et validés avant utilisation.
+
 ## Personnalisation de produits
 Un bouton "Personnaliser ce produit" ouvre un modale sur la fiche produit pour choisir un design, saisir du texte ou importer une image. Les sélections sont temporairement sauvegardées via localStorage.

--- a/templates/admin/partials/configuration-form.php
+++ b/templates/admin/partials/configuration-form.php
@@ -1,3 +1,21 @@
 <form method="post" action="options.php">
-  <p>Paramètres de WinShirt à venir.</p>
+    <?php
+    settings_fields('winshirt_options');
+    do_settings_sections('winshirt_options');
+    ?>
+    <table class="form-table">
+        <tr>
+            <th scope="row"><label for="winshirt-ftp-host">FTP Host</label></th>
+            <td><input name="winshirt_ftp_host" id="winshirt-ftp-host" type="text" value="<?php echo esc_attr(get_option('winshirt_ftp_host')); ?>" class="regular-text" /></td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="winshirt-ftp-user">FTP User</label></th>
+            <td><input name="winshirt_ftp_user" id="winshirt-ftp-user" type="text" value="<?php echo esc_attr(get_option('winshirt_ftp_user')); ?>" class="regular-text" /></td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="winshirt-ftp-pass">FTP Password</label></th>
+            <td><input name="winshirt_ftp_pass" id="winshirt-ftp-pass" type="password" value="<?php echo esc_attr(get_option('winshirt_ftp_pass')); ?>" class="regular-text" /></td>
+        </tr>
+    </table>
+    <?php submit_button(); ?>
 </form>

--- a/templates/admin/partials/visuels-list.php
+++ b/templates/admin/partials/visuels-list.php
@@ -1,1 +1,101 @@
-<p>Bibliothèque des visuels à venir.</p>
+<?php
+/**
+ * Admin visual management interface.
+ * Variables: $visuals, $filters, $types
+ */
+?>
+<form method="get" style="margin-bottom:15px;">
+    <input type="hidden" name="page" value="winshirt-designs" />
+    <select name="type">
+        <option value=""><?php esc_html_e('Tous les types', 'winshirt'); ?></option>
+        <?php foreach ($types as $t) : ?>
+            <option value="<?php echo esc_attr($t); ?>" <?php selected($filters['type'], $t); ?>><?php echo esc_html($t); ?></option>
+        <?php endforeach; ?>
+    </select>
+    <input type="date" name="date" value="<?php echo esc_attr($filters['date']); ?>" />
+    <input type="submit" class="button" value="<?php esc_attr_e('Filtrer', 'winshirt'); ?>" />
+</form>
+
+<form method="post">
+    <?php wp_nonce_field('winshirt_bulk_action', 'winshirt_bulk_nonce'); ?>
+    <table class="widefat fixed">
+        <thead>
+            <tr>
+                <th style="width:20px;"><input type="checkbox" id="select-all" /></th>
+                <th><?php esc_html_e('Miniature', 'winshirt'); ?></th>
+                <th><?php esc_html_e('Nom', 'winshirt'); ?></th>
+                <th><?php esc_html_e('Type', 'winshirt'); ?></th>
+                <th><?php esc_html_e('Date', 'winshirt'); ?></th>
+                <th><?php esc_html_e('Actions', 'winshirt'); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php if ($visuals) : ?>
+                <?php foreach ($visuals as $visual) :
+                    $type = get_post_meta($visual->ID, '_winshirt_visual_type', true);
+                    $validated = get_post_meta($visual->ID, '_winshirt_visual_validated', true) === 'yes';
+                ?>
+                <tr>
+                    <td><input type="checkbox" name="selected[]" value="<?php echo esc_attr($visual->ID); ?>" /></td>
+                    <td><?php echo get_the_post_thumbnail($visual->ID, 'thumbnail'); ?></td>
+                    <td><?php echo esc_html($visual->post_title); ?></td>
+                    <td><?php echo esc_html($type); ?></td>
+                    <td><?php echo esc_html(get_the_date('', $visual)); ?></td>
+                    <td>
+                        <?php if (!$validated) : ?>
+                            <a class="button" href="<?php echo esc_url(wp_nonce_url(add_query_arg(['page' => 'winshirt-designs', 'validate' => $visual->ID], admin_url('admin.php')), 'validate_visual_' . $visual->ID)); ?>"><?php esc_html_e('Valider ce visuel', 'winshirt'); ?></a>
+                        <?php endif; ?>
+                        <a class="button delete" href="<?php echo esc_url(wp_nonce_url(add_query_arg(['page' => 'winshirt-designs', 'delete' => $visual->ID], admin_url('admin.php')), 'delete_visual_' . $visual->ID)); ?>"><?php esc_html_e('Supprimer', 'winshirt'); ?></a>
+                    </td>
+                </tr>
+                <?php endforeach; ?>
+            <?php else : ?>
+                <tr><td colspan="6"><?php esc_html_e('Aucun visuel', 'winshirt'); ?></td></tr>
+            <?php endif; ?>
+        </tbody>
+    </table>
+    <p>
+        <select name="bulk_action">
+            <option value=""><?php esc_html_e('Actions groupées', 'winshirt'); ?></option>
+            <option value="delete"><?php esc_html_e('Supprimer', 'winshirt'); ?></option>
+        </select>
+        <input type="submit" class="button" value="<?php esc_attr_e('Appliquer', 'winshirt'); ?>" />
+    </p>
+</form>
+
+<hr/>
+
+<h2><?php esc_html_e('Ajouter un visuel', 'winshirt'); ?></h2>
+<form method="post" enctype="multipart/form-data">
+    <?php wp_nonce_field('winshirt_add_visual', 'winshirt_visual_nonce'); ?>
+    <table class="form-table">
+        <tr>
+            <th scope="row"><label for="visual-title"><?php esc_html_e('Nom', 'winshirt'); ?></label></th>
+            <td><input name="title" id="visual-title" type="text" class="regular-text" required /></td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="visual-file"><?php esc_html_e('Fichier', 'winshirt'); ?></label></th>
+            <td><input type="file" name="file" id="visual-file" required /></td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="visual-type"><?php esc_html_e('Type', 'winshirt'); ?></label></th>
+            <td>
+                <select name="type" id="visual-type">
+                    <?php foreach ($types as $t) { echo '<option value="' . esc_attr($t) . '">' . esc_html($t) . '</option>'; } ?>
+                </select>
+            </td>
+        </tr>
+    </table>
+    <p><input type="submit" class="button button-primary" value="<?php esc_attr_e('Uploader', 'winshirt'); ?>" /></p>
+</form>
+
+<script>
+(function(){
+    const master = document.getElementById('select-all');
+    if(master){
+        master.addEventListener('change', function(){
+            document.querySelectorAll('input[name="selected[]"]').forEach(function(c){ c.checked = master.checked; });
+        });
+    }
+})();
+</script>


### PR DESCRIPTION
## Summary
- implement custom post type for visuals and FTP options
- add interface to manage visuals with upload, filter, validation and bulk delete
- store FTP credentials in configuration form
- update documentation

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68511fd1fcc88329ba9fa2e546815f2a