### PR TITLE
Add customizable products admin features

### DIFF
--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -6,11 +6,17 @@ jQuery(function($){
     }
 
     function loadState(){
+        var frontDefault = $('#winshirt-modal').data('default-front') || '';
+        var backDefault  = $('#winshirt-modal').data('default-back') || '';
         if(state.front){
             $('#winshirt-preview-front img').attr('src', state.front);
+        } else if(frontDefault){
+            $('#winshirt-preview-front img').attr('src', frontDefault);
         }
         if(state.back){
             $('#winshirt-preview-back img').attr('src', state.back);
+        } else if(backDefault){
+            $('#winshirt-preview-back img').attr('src', backDefault);
         }
         if(state.text){
             $('#winshirt-text-input').val(state.text);

--- a/includes/init.php
+++ b/includes/init.php
@@ -36,10 +36,28 @@ add_action('admin_enqueue_scripts', function ($hook) {
 
 // Add customize button and modal on product page
 function winshirt_render_customize_button() {
-    echo '<button id="winshirt-open-modal" class="button">' . esc_html__('Personnaliser ce produit', 'winshirt') . '</button>';
+    global $product;
+    if ( ! $product instanceof WC_Product ) {
+        return;
+    }
+
+    $pid        = $product->get_id();
+    $show       = get_post_meta( $pid, '_winshirt_show_button', true );
+    if ( 'yes' !== $show ) {
+        return;
+    }
+
+    $front_id   = absint( get_post_meta( $pid, '_winshirt_default_mockup_front', true ) );
+    $back_id    = absint( get_post_meta( $pid, '_winshirt_default_mockup_back', true ) );
+    $front_url  = $front_id ? get_the_post_thumbnail_url( $front_id, 'full' ) : '';
+    $back_url   = $back_id ? get_the_post_thumbnail_url( $back_id, 'full' ) : '';
+
+    echo '<button id="winshirt-open-modal" class="button">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button>';
+    $default_front = $front_url;
+    $default_back  = $back_url;
     include WINSHIRT_PATH . 'templates/frontend/modal-personnalisation.php';
 }
-add_action('woocommerce_single_product_summary', 'winshirt_render_customize_button', 35);
+add_action( 'woocommerce_single_product_summary', 'winshirt_render_customize_button', 35 );
 
 // Register custom post type for mockups
 add_action('init', function () {

--- a/includes/pages/produits.php
+++ b/includes/pages/produits.php
@@ -5,9 +5,16 @@ function winshirt_page_products() {
     if (isset($_POST['winshirt_product_nonce']) && wp_verify_nonce($_POST['winshirt_product_nonce'], 'save_winshirt_product_meta')) {
         $product_id = absint($_POST['product_id']);
 
-        update_post_meta($product_id, '_winshirt_mockups', sanitize_text_field($_POST['winshirt_mockups'] ?? ''));
+        $mockups = isset($_POST['winshirt_mockups']) ? array_map('intval', (array) $_POST['winshirt_mockups']) : [];
+        update_post_meta($product_id, '_winshirt_mockups', implode(',', $mockups));
+
         update_post_meta($product_id, '_winshirt_visuals', sanitize_text_field($_POST['winshirt_visuals'] ?? ''));
         update_post_meta($product_id, '_winshirt_lottery', sanitize_text_field($_POST['winshirt_lottery'] ?? ''));
+
+        update_post_meta($product_id, '_winshirt_default_mockup_front', absint($_POST['winshirt_default_front'] ?? 0));
+        update_post_meta($product_id, '_winshirt_default_mockup_back', absint($_POST['winshirt_default_back'] ?? 0));
+
+        update_post_meta($product_id, '_winshirt_show_button', isset($_POST['winshirt_show_button']) ? 'yes' : 'no');
         update_post_meta($product_id, '_winshirt_enabled', isset($_POST['winshirt_enabled']) ? 'yes' : 'no');
 
         echo '<div class="updated"><p>' . esc_html__('Metadonnees enregistrees.', 'winshirt') . '</p></div>';
@@ -18,6 +25,12 @@ function winshirt_page_products() {
         'search' => $search,
         'limit'  => -1,
         'status' => 'publish',
+    ]);
+
+    $all_mockups = get_posts([
+        'post_type'   => 'winshirt_mockup',
+        'numberposts' => -1,
+        'orderby'     => 'title',
     ]);
 
     echo '<div class="wrap"><h1>' . esc_html__('Produits', 'winshirt') . '</h1>';

--- a/templates/admin/partials/produits-list.php
+++ b/templates/admin/partials/produits-list.php
@@ -12,10 +12,10 @@
     <thead>
         <tr>
             <th><?php esc_html_e( 'Produit', 'winshirt' ); ?></th>
+            <th style="text-align:center;"><?php esc_html_e( 'Personnalisable', 'winshirt' ); ?></th>
+            <th style="text-align:center;"><?php esc_html_e( 'Afficher bouton', 'winshirt' ); ?></th>
             <th><?php esc_html_e( 'Mockups', 'winshirt' ); ?></th>
-            <th><?php esc_html_e( 'Visuels', 'winshirt' ); ?></th>
             <th><?php esc_html_e( 'Loterie', 'winshirt' ); ?></th>
-            <th><?php esc_html_e( 'Personnalisation', 'winshirt' ); ?></th>
             <th><?php esc_html_e( 'Action', 'winshirt' ); ?></th>
         </tr>
     </thead>
@@ -23,18 +23,45 @@
     <?php if ( $products ) : ?>
         <?php foreach ( $products as $product ) : ?>
             <?php
-                $pid     = $product->get_id();
-                $mockups = get_post_meta( $pid, '_winshirt_mockups', true );
-                $visuals = get_post_meta( $pid, '_winshirt_visuals', true );
-                $lottery = get_post_meta( $pid, '_winshirt_lottery', true );
-                $enabled = get_post_meta( $pid, '_winshirt_enabled', true ) === 'yes';
+                $pid           = $product->get_id();
+                $mockups_raw   = get_post_meta( $pid, '_winshirt_mockups', true );
+                $mockups       = $mockups_raw ? array_map( 'intval', explode( ',', $mockups_raw ) ) : [];
+                $lottery       = get_post_meta( $pid, '_winshirt_lottery', true );
+                $enabled       = get_post_meta( $pid, '_winshirt_enabled', true ) === 'yes';
+                $show_button   = get_post_meta( $pid, '_winshirt_show_button', true ) === 'yes';
+                $default_front = absint( get_post_meta( $pid, '_winshirt_default_mockup_front', true ) );
+                $default_back  = absint( get_post_meta( $pid, '_winshirt_default_mockup_back', true ) );
             ?>
             <tr>
                 <td><?php echo esc_html( $product->get_name() ); ?></td>
-                <td><input type="text" name="winshirt_mockups" value="<?php echo esc_attr( $mockups ); ?>" form="winshirt-form-<?php echo esc_attr( $pid ); ?>" /></td>
-                <td><input type="text" name="winshirt_visuals" value="<?php echo esc_attr( $visuals ); ?>" form="winshirt-form-<?php echo esc_attr( $pid ); ?>" /></td>
-                <td><input type="text" name="winshirt_lottery" value="<?php echo esc_attr( $lottery ); ?>" form="winshirt-form-<?php echo esc_attr( $pid ); ?>" /></td>
                 <td style="text-align:center;"><input type="checkbox" name="winshirt_enabled" value="1" <?php checked( $enabled ); ?> form="winshirt-form-<?php echo esc_attr( $pid ); ?>" /></td>
+                <td style="text-align:center;"><input type="checkbox" name="winshirt_show_button" value="1" <?php checked( $show_button ); ?> form="winshirt-form-<?php echo esc_attr( $pid ); ?>" /></td>
+                <td>
+                    <select name="winshirt_mockups[]" multiple size="3" form="winshirt-form-<?php echo esc_attr( $pid ); ?>">
+                        <?php foreach ( $all_mockups as $m ) : ?>
+                            <option value="<?php echo esc_attr( $m->ID ); ?>" <?php selected( in_array( $m->ID, $mockups, true ) ); ?>><?php echo esc_html( $m->post_title ); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                    <br />
+                    <label><?php esc_html_e( 'Mockup recto', 'winshirt' ); ?>
+                        <select name="winshirt_default_front" form="winshirt-form-<?php echo esc_attr( $pid ); ?>">
+                            <option value="">-<?php esc_html_e( 'Aucun', 'winshirt' ); ?>-</option>
+                            <?php foreach ( $all_mockups as $m ) : ?>
+                                <option value="<?php echo esc_attr( $m->ID ); ?>" <?php selected( $default_front, $m->ID ); ?>><?php echo esc_html( $m->post_title ); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </label>
+                    <br />
+                    <label><?php esc_html_e( 'Mockup verso', 'winshirt' ); ?>
+                        <select name="winshirt_default_back" form="winshirt-form-<?php echo esc_attr( $pid ); ?>">
+                            <option value="">-<?php esc_html_e( 'Aucun', 'winshirt' ); ?>-</option>
+                            <?php foreach ( $all_mockups as $m ) : ?>
+                                <option value="<?php echo esc_attr( $m->ID ); ?>" <?php selected( $default_back, $m->ID ); ?>><?php echo esc_html( $m->post_title ); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </label>
+                </td>
+                <td><input type="text" name="winshirt_lottery" value="<?php echo esc_attr( $lottery ); ?>" form="winshirt-form-<?php echo esc_attr( $pid ); ?>" /></td>
                 <td>
                     <form method="post" id="winshirt-form-<?php echo esc_attr( $pid ); ?>">
                         <?php wp_nonce_field( 'save_winshirt_product_meta', 'winshirt_product_nonce' ); ?>

--- a/templates/frontend/modal-personnalisation.php
+++ b/templates/frontend/modal-personnalisation.php
@@ -1,4 +1,4 @@
-<div id="winshirt-modal" class="winshirt-modal">
+<div id="winshirt-modal" class="winshirt-modal" data-default-front="<?php echo esc_attr( $default_front ?? '' ); ?>" data-default-back="<?php echo esc_attr( $default_back ?? '' ); ?>">
   <div class="winshirt-modal-content">
     <span class="winshirt-close">&times;</span>
     <ul class="winshirt-tab-links">
@@ -33,11 +33,11 @@
     </div>
     <div class="winshirt-preview">
       <div id="winshirt-preview-front" style="display:none;position:relative;">
-        <img src="" alt="Preview front" />
+        <img src="<?php echo esc_url( $default_front ?? '' ); ?>" alt="Preview front" />
         <span class="winshirt-text"></span>
       </div>
       <div id="winshirt-preview-back" style="display:none;position:relative;">
-        <img src="" alt="Preview back" />
+        <img src="<?php echo esc_url( $default_back ?? '' ); ?>" alt="Preview back" />
         <span class="winshirt-text"></span>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- extend product admin page to manage customisation settings
- allow multiple mockups, default mockups and lottery link
- show or hide the "Personnaliser" button per product
- load default mockups on the frontend modal

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685121561e64832999faa529d93712c4