### PR TITLE
Add lottery management page

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -9,6 +9,16 @@ add_action('wp_enqueue_scripts', function () {
     }
 });
 
+// Register custom post type for lotteries
+add_action('init', function () {
+    register_post_type('winshirt_lottery', [
+        'label'       => 'Loteries',
+        'public'      => false,
+        'show_ui'     => false,
+        'supports'    => ['title', 'editor', 'thumbnail'],
+    ]);
+});
+
 // Register custom post type for visuals
 add_action('init', function () {
     register_post_type('winshirt_visual', [

--- a/includes/pages/loteries.php
+++ b/includes/pages/loteries.php
@@ -2,7 +2,69 @@
 defined('ABSPATH') || exit;
 
 function winshirt_page_lotteries() {
-    echo '<div class="wrap"><h1>Gestion des loteries</h1>';
+    $editing = null;
+    $participants = [];
+
+    // Handle deletion
+    if (isset($_GET['delete']) && isset($_GET['_wpnonce']) && wp_verify_nonce($_GET['_wpnonce'], 'delete_lottery_' . absint($_GET['delete']))) {
+        wp_delete_post(absint($_GET['delete']), true);
+        echo '<div class="updated"><p>' . esc_html__('Loterie supprimee.', 'winshirt') . '</p></div>';
+    }
+
+    // Handle edit request
+    if (isset($_GET['edit'])) {
+        $editing = get_post(absint($_GET['edit']));
+        $participants = get_post_meta($editing->ID, '_winshirt_lottery_participants', true);
+        $participants = is_array($participants) ? $participants : [];
+    }
+
+    // Handle form submission
+    if (isset($_POST['winshirt_lottery_nonce']) && wp_verify_nonce($_POST['winshirt_lottery_nonce'], 'save_winshirt_lottery')) {
+        $lottery_id = isset($_POST['lottery_id']) ? absint($_POST['lottery_id']) : 0;
+
+        $data = [
+            'post_type'   => 'winshirt_lottery',
+            'post_title'  => sanitize_text_field($_POST['title'] ?? ''),
+            'post_content'=> sanitize_textarea_field($_POST['description'] ?? ''),
+            'post_status' => 'publish',
+        ];
+
+        if ($lottery_id) {
+            $data['ID'] = $lottery_id;
+            wp_update_post($data);
+        } else {
+            $lottery_id = wp_insert_post($data);
+        }
+
+        update_post_meta($lottery_id, '_winshirt_lottery_start', sanitize_text_field($_POST['start'] ?? ''));
+        update_post_meta($lottery_id, '_winshirt_lottery_end', sanitize_text_field($_POST['end'] ?? ''));
+        update_post_meta($lottery_id, '_winshirt_lottery_prizes', sanitize_textarea_field($_POST['prizes'] ?? ''));
+        update_post_meta($lottery_id, '_winshirt_lottery_product', absint($_POST['product'] ?? 0));
+        update_post_meta($lottery_id, '_winshirt_lottery_active', isset($_POST['active']) ? 'yes' : 'no');
+        update_post_meta($lottery_id, '_winshirt_lottery_draw', in_array($_POST['draw'] ?? 'manual', ['manual','auto'], true) ? $_POST['draw'] : 'manual');
+
+        if (!empty($_FILES['animation']['tmp_name'])) {
+            require_once ABSPATH . 'wp-admin/includes/file.php';
+            require_once ABSPATH . 'wp-admin/includes/image.php';
+            $attachment_id = media_handle_upload('animation', 0);
+            if (!is_wp_error($attachment_id)) {
+                update_post_meta($lottery_id, '_winshirt_lottery_animation', $attachment_id);
+            }
+        }
+
+        echo '<div class="updated"><p>' . esc_html__('Loterie enregistree.', 'winshirt') . '</p></div>';
+        $editing = get_post($lottery_id);
+        $participants = get_post_meta($lottery_id, '_winshirt_lottery_participants', true);
+        $participants = is_array($participants) ? $participants : [];
+    }
+
+    $lotteries = get_posts([
+        'post_type'   => 'winshirt_lottery',
+        'numberposts' => -1,
+        'orderby'     => 'date',
+    ]);
+
+    echo '<div class="wrap"><h1>' . esc_html__('Gestion des loteries', 'winshirt') . '</h1>';
     include WINSHIRT_PATH . 'templates/admin/partials/loteries-list.php';
     echo '</div>';
 }

--- a/readme.txt
+++ b/readme.txt
@@ -16,3 +16,6 @@ L'onglet "Visuels" permet d'importer ou supprimer des images. Les visuels peuven
 
 ## Personnalisation de produits
 Un bouton "Personnaliser ce produit" ouvre un modale sur la fiche produit pour choisir un design, saisir du texte ou importer une image. Les sélections sont temporairement sauvegardées via localStorage.
+
+## Gestion des loteries
+Une page "Loteries" permet de créer et d'administrer les tirages. Chaque loterie peut être liée à un produit WooCommerce, disposer de dates de début/fin, de lots à gagner et d'une animation personnalisée. Les participants enregistrés et leur nombre sont visibles depuis cette interface.

--- a/templates/admin/partials/loteries-list.php
+++ b/templates/admin/partials/loteries-list.php
@@ -1,1 +1,112 @@
-<p>Configuration des règles de loterie à venir.</p>
+<?php
+/**
+ * Admin lottery management interface.
+ * Variables: $lotteries, $editing, $participants
+ */
+?>
+<table class="widefat fixed">
+    <thead>
+        <tr>
+            <th><?php esc_html_e('Titre', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Produit', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Dates', 'winshirt'); ?></th>
+            <th style="text-align:center;">Actif</th>
+            <th><?php esc_html_e('Participations', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Actions', 'winshirt'); ?></th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php if ($lotteries) : ?>
+        <?php foreach ($lotteries as $lottery) : ?>
+            <?php
+                $start  = get_post_meta($lottery->ID, '_winshirt_lottery_start', true);
+                $end    = get_post_meta($lottery->ID, '_winshirt_lottery_end', true);
+                $product= get_post_meta($lottery->ID, '_winshirt_lottery_product', true);
+                $active = get_post_meta($lottery->ID, '_winshirt_lottery_active', true) === 'yes';
+                $parts  = get_post_meta($lottery->ID, '_winshirt_lottery_participants', true);
+                $count  = is_array($parts) ? count($parts) : 0;
+            ?>
+            <tr>
+                <td><?php echo esc_html($lottery->post_title); ?></td>
+                <td><?php echo esc_html($product); ?></td>
+                <td><?php echo esc_html($start . ' - ' . $end); ?></td>
+                <td style="text-align:center;"><input type="checkbox" disabled <?php checked($active); ?> /></td>
+                <td><?php echo esc_html($count); ?></td>
+                <td>
+                    <a class="button" href="<?php echo esc_url(add_query_arg(['page' => 'winshirt-lotteries', 'edit' => $lottery->ID], admin_url('admin.php'))); ?>"><?php esc_html_e('Modifier', 'winshirt'); ?></a>
+                    <a class="button delete" href="<?php echo esc_url(wp_nonce_url(add_query_arg(['page' => 'winshirt-lotteries', 'delete' => $lottery->ID], admin_url('admin.php')), 'delete_lottery_' . $lottery->ID)); ?>"><?php esc_html_e('Supprimer', 'winshirt'); ?></a>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+    <?php else : ?>
+        <tr><td colspan="6"><?php esc_html_e('Aucune loterie', 'winshirt'); ?></td></tr>
+    <?php endif; ?>
+    </tbody>
+</table>
+
+<?php if ($editing) : ?>
+<h2><?php esc_html_e('Participants', 'winshirt'); ?> (<?php echo count($participants); ?>)</h2>
+<?php if ($participants) : ?>
+    <ul style="list-style:disc;padding-left:20px;">
+        <?php foreach ($participants as $p) { echo '<li>' . esc_html($p) . '</li>'; } ?>
+    </ul>
+<?php else : ?>
+    <p><?php esc_html_e('Aucun participant', 'winshirt'); ?></p>
+<?php endif; ?>
+<?php endif; ?>
+
+<hr/>
+
+<h2><?php echo $editing ? esc_html__('Modifier la loterie', 'winshirt') : esc_html__('Ajouter une loterie', 'winshirt'); ?></h2>
+<form method="post" enctype="multipart/form-data">
+    <?php wp_nonce_field('save_winshirt_lottery', 'winshirt_lottery_nonce'); ?>
+    <input type="hidden" name="lottery_id" value="<?php echo esc_attr($editing->ID ?? 0); ?>" />
+    <table class="form-table">
+        <tr>
+            <th scope="row"><label for="lottery-title">Titre</label></th>
+            <td><input name="title" id="lottery-title" type="text" class="regular-text" value="<?php echo esc_attr($editing->post_title ?? ''); ?>" required /></td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="lottery-description">Description</label></th>
+            <td><textarea name="description" id="lottery-description" rows="4" class="large-text"><?php echo esc_textarea($editing->post_content ?? ''); ?></textarea></td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="lottery-start">Date de début</label></th>
+            <td><input type="date" name="start" id="lottery-start" value="<?php echo esc_attr(get_post_meta($editing->ID ?? 0, '_winshirt_lottery_start', true)); ?>" /></td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="lottery-end">Date de fin</label></th>
+            <td><input type="date" name="end" id="lottery-end" value="<?php echo esc_attr(get_post_meta($editing->ID ?? 0, '_winshirt_lottery_end', true)); ?>" /></td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="lottery-prizes">Lots à gagner</label></th>
+            <td><textarea name="prizes" id="lottery-prizes" rows="3" class="large-text"><?php echo esc_textarea(get_post_meta($editing->ID ?? 0, '_winshirt_lottery_prizes', true)); ?></textarea></td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="lottery-product">Produit WooCommerce (ID)</label></th>
+            <td><input type="number" name="product" id="lottery-product" value="<?php echo esc_attr(get_post_meta($editing->ID ?? 0, '_winshirt_lottery_product', true)); ?>" /></td>
+        </tr>
+        <tr>
+            <th scope="row">Active</th>
+            <td><label><input type="checkbox" name="active" value="1" <?php checked(get_post_meta($editing->ID ?? 0, '_winshirt_lottery_active', true), 'yes'); ?> /> <?php esc_html_e('Activer cette loterie', 'winshirt'); ?></label></td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="lottery-draw">Tirage au sort</label></th>
+            <td>
+                <?php $draw = get_post_meta($editing->ID ?? 0, '_winshirt_lottery_draw', true) ?: 'manual'; ?>
+                <select name="draw" id="lottery-draw">
+                    <option value="manual" <?php selected($draw, 'manual'); ?>><?php esc_html_e('Manuel', 'winshirt'); ?></option>
+                    <option value="auto" <?php selected($draw, 'auto'); ?>><?php esc_html_e('Automatique à la date de fin', 'winshirt'); ?></option>
+                </select>
+            </td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="lottery-animation">Animation/Image</label></th>
+            <td>
+                <input type="file" name="animation" id="lottery-animation" />
+                <?php $anim = get_post_meta($editing->ID ?? 0, '_winshirt_lottery_animation', true); if ($anim) { echo wp_get_attachment_image($anim, 'thumbnail'); } ?>
+            </td>
+        </tr>
+    </table>
+    <p><input type="submit" class="button button-primary" value="<?php echo $editing ? esc_attr__('Mettre à jour', 'winshirt') : esc_attr__('Ajouter la loterie', 'winshirt'); ?>" /></p>
+</form>


### PR DESCRIPTION
## Summary
- add CPT for lotteries
- implement management page with add/edit form
- list participants and activation status
- document the feature in readme

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6851234e2a4083299e9138ec68e5fe40