### PR TITLE
Add production order management page

### DIFF
--- a/includes/pages/commandes.php
+++ b/includes/pages/commandes.php
@@ -1,8 +1,111 @@
 <?php
 defined('ABSPATH') || exit;
 
+/**
+ * Display and manage WinShirt orders for production.
+ */
 function winshirt_page_orders() {
+    $filters = [
+        'status'    => sanitize_text_field($_GET['status'] ?? ''),
+        'date_from' => sanitize_text_field($_GET['date_from'] ?? ''),
+        'date_to'   => sanitize_text_field($_GET['date_to'] ?? ''),
+    ];
+
+    // Handle production validation
+    if (isset($_POST['production_validate'], $_POST['order_id'], $_POST['validate_nonce']) && wp_verify_nonce($_POST['validate_nonce'], 'validate_production_' . absint($_POST['order_id']))) {
+        update_post_meta(absint($_POST['order_id']), '_winshirt_production_validated', 'yes');
+        if (!get_post_meta(absint($_POST['order_id']), '_winshirt_production_status', true)) {
+            update_post_meta(absint($_POST['order_id']), '_winshirt_production_status', 'En cours');
+        }
+        echo '<div class="updated"><p>' . esc_html__('Production validée.', 'winshirt') . '</p></div>';
+    }
+
+    // Handle CSV export
+    if (isset($_GET['export']) && isset($_GET['_wpnonce']) && wp_verify_nonce($_GET['_wpnonce'], 'winshirt_export_csv')) {
+        $orders = winshirt_get_production_orders($filters);
+        winshirt_export_orders_csv($orders);
+        exit;
+    }
+
+    $orders = winshirt_get_production_orders($filters);
+
     echo '<div class="wrap"><h1>Commandes WinShirt</h1>';
     include WINSHIRT_PATH . 'templates/admin/partials/commandes-list.php';
     echo '</div>';
+}
+
+/**
+ * Retrieve orders containing WinShirt enabled products.
+ *
+ * @param array $filters Optional filters.
+ * @return WC_Order[]
+ */
+function winshirt_get_production_orders(array $filters = []) {
+    $args   = [
+        'limit'  => -1,
+        'orderby'=> 'date',
+        'order'  => 'DESC',
+    ];
+    $orders = wc_get_orders($args);
+    $result = [];
+
+    foreach ($orders as $order) {
+        $include = false;
+        foreach ($order->get_items() as $item) {
+            $pid = $item->get_product_id();
+            if (get_post_meta($pid, '_winshirt_enabled', true) === 'yes') {
+                $include = true;
+                break;
+            }
+        }
+        if (!$include) {
+            continue;
+        }
+
+        $status = $order->get_meta('_winshirt_production_status');
+        if ($filters['status'] && $filters['status'] !== $status) {
+            continue;
+        }
+
+        $created = $order->get_date_created();
+        if ($created) {
+            $created = $created->format('Y-m-d');
+            if ($filters['date_from'] && $created < $filters['date_from']) {
+                continue;
+            }
+            if ($filters['date_to'] && $created > $filters['date_to']) {
+                continue;
+            }
+        }
+
+        $result[] = $order;
+    }
+
+    return $result;
+}
+
+/**
+ * Output a CSV export of orders.
+ *
+ * @param WC_Order[] $orders Orders to export.
+ */
+function winshirt_export_orders_csv(array $orders) {
+    header('Content-Type: text/csv');
+    header('Content-Disposition: attachment; filename="commandes-winshirt.csv"');
+    $out = fopen('php://output', 'w');
+    fputcsv($out, ['ID', 'Client', 'Produit', 'Fichier recto', 'Fichier verso', 'Statut']);
+    foreach ($orders as $order) {
+        foreach ($order->get_items() as $item) {
+            $pid = $item->get_product_id();
+            if (get_post_meta($pid, '_winshirt_enabled', true) !== 'yes') {
+                continue;
+            }
+            $customer = $order->get_billing_first_name() . ' ' . $order->get_billing_last_name();
+            $front    = $item->get_meta('winshirt_front_hd');
+            $back     = $item->get_meta('winshirt_back_hd');
+            $status   = $order->get_meta('_winshirt_production_status') ?: 'A produire';
+            fputcsv($out, [$order->get_id(), $customer, $item->get_name(), $front, $back, $status]);
+        }
+    }
+    fclose($out);
 }

--- a/templates/admin/partials/commandes-list.php
+++ b/templates/admin/partials/commandes-list.php
@@ -1,16 +1,88 @@
+<?php
+/**
+ * List of WinShirt orders for production.
+ * Variables: $orders, $filters
+ */
+?>
+<form method="get" style="margin-bottom:15px;">
+    <input type="hidden" name="page" value="winshirt-orders" />
+    <select name="status">
+        <option value=""><?php esc_html_e('Tous les statuts', 'winshirt'); ?></option>
+        <?php
+        $statuses = ['A produire', 'En cours', 'Expédié'];
+        foreach ($statuses as $s) {
+            echo '<option value="' . esc_attr($s) . '" ' . selected($filters['status'], $s, false) . '>' . esc_html($s) . '</option>';
+        }
+        ?>
+    </select>
+    <input type="date" name="date_from" value="<?php echo esc_attr($filters['date_from']); ?>" />
+    <input type="date" name="date_to" value="<?php echo esc_attr($filters['date_to']); ?>" />
+    <input type="submit" class="button" value="<?php esc_attr_e('Filtrer', 'winshirt'); ?>" />
+    <a class="button" href="<?php echo esc_url(wp_nonce_url(add_query_arg(array_merge($_GET, ['export' => 1]), admin_url('admin.php')), 'winshirt_export_csv')); ?>">Export CSV</a>
+</form>
 <table class="widefat fixed">
-  <thead>
-    <tr>
-      <th>Client</th>
-      <th>Produit</th>
-      <th>Statut production</th>
-      <th>Date</th>
-      <th>Actions</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td colspan="5">Aucune commande pour le moment.</td>
-    </tr>
-  </tbody>
+    <thead>
+        <tr>
+            <th><?php esc_html_e('ID', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Client', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Produit', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Recto', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Verso', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Statut', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Valider', 'winshirt'); ?></th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php if ($orders) : ?>
+            <?php foreach ($orders as $order) : ?>
+                <?php foreach ($order->get_items() as $item) : ?>
+                    <?php if (get_post_meta($item->get_product_id(), '_winshirt_enabled', true) !== 'yes') { continue; } ?>
+                    <?php
+                        $front_prev = $item->get_meta('winshirt_front_preview');
+                        $back_prev  = $item->get_meta('winshirt_back_preview');
+                        $front_hd   = $item->get_meta('winshirt_front_hd');
+                        $back_hd    = $item->get_meta('winshirt_back_hd');
+                        $status     = $order->get_meta('_winshirt_production_status') ?: 'A produire';
+                        $validated  = $order->get_meta('_winshirt_production_validated') === 'yes';
+                    ?>
+                    <tr>
+                        <td><?php echo esc_html($order->get_id()); ?></td>
+                        <td><?php echo esc_html($order->get_billing_first_name() . ' ' . $order->get_billing_last_name()); ?></td>
+                        <td><?php echo esc_html($item->get_name()); ?></td>
+                        <td>
+                            <?php if ($front_prev) : ?>
+                                <img src="<?php echo esc_url($front_prev); ?>" style="max-width:80px;height:auto;" alt="front" />
+                            <?php endif; ?>
+                            <?php if ($front_hd) : ?>
+                                <br/><a class="button" href="<?php echo esc_url($front_hd); ?>" download><?php esc_html_e('Télécharger', 'winshirt'); ?></a>
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <?php if ($back_prev) : ?>
+                                <img src="<?php echo esc_url($back_prev); ?>" style="max-width:80px;height:auto;" alt="back" />
+                            <?php endif; ?>
+                            <?php if ($back_hd) : ?>
+                                <br/><a class="button" href="<?php echo esc_url($back_hd); ?>" download><?php esc_html_e('Télécharger', 'winshirt'); ?></a>
+                            <?php endif; ?>
+                        </td>
+                        <td><?php echo esc_html($status); ?></td>
+                        <td>
+                            <?php if (!$validated) : ?>
+                                <form method="post">
+                                    <?php wp_nonce_field('validate_production_' . $order->get_id(), 'validate_nonce'); ?>
+                                    <input type="hidden" name="order_id" value="<?php echo esc_attr($order->get_id()); ?>" />
+                                    <input type="hidden" name="production_validate" value="1" />
+                                    <input type="submit" class="button" value="<?php esc_attr_e('Valider cette production', 'winshirt'); ?>" />
+                                </form>
+                            <?php else : ?>
+                                <?php esc_html_e('Validée', 'winshirt'); ?>
+                            <?php endif; ?>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            <?php endforeach; ?>
+        <?php else : ?>
+            <tr><td colspan="7"><?php esc_html_e('Aucune commande', 'winshirt'); ?></td></tr>
+        <?php endif; ?>
+    </tbody>
 </table>


### PR DESCRIPTION
## Summary
- implement WinShirt order management functions
- allow CSV export of production orders
- show customizable orders with filtering and validation

## Testing
- `php -l includes/pages/commandes.php` *(fails: command not found)*
- `php -l templates/admin/partials/commandes-list.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685125162e908329adaa86e8c11cd422