### PR TITLE
Enhance mockup admin management

### DIFF
--- a/assets/css/winshirt-mockups.css
+++ b/assets/css/winshirt-mockups.css
@@ -1,0 +1,5 @@
+#colors-container .color-row{margin-bottom:10px;border:1px solid #ddd;padding:10px;position:relative;}
+#colors-container .remove-color{position:absolute;top:4px;right:4px;}
+#print-zone-wrapper{margin-top:15px;}
+#print-zone-wrapper #mockup-canvas{position:relative;display:inline-block;border:1px solid #ccc;}
+#print-zone-wrapper .print-zone{border:2px dashed #f00;position:absolute;background:rgba(255,0,0,0.2);text-align:center;color:#000;}

--- a/assets/js/winshirt-mockups.js
+++ b/assets/js/winshirt-mockups.js
@@ -1,0 +1,43 @@
+jQuery(function($){
+    $('#add-color').on('click', function(e){
+        e.preventDefault();
+        var index = $('#colors-container .color-row').length;
+        var template = $('#color-template').html();
+        template = template.replace(/%i%/g, index);
+        $('#colors-container').append(template);
+    });
+
+    $(document).on('click', '.remove-color', function(e){
+        e.preventDefault();
+        $(this).closest('.color-row').remove();
+    });
+
+    function initZones(){
+        $('.print-zone').each(function(){
+            var $z = $(this);
+            $z.draggable({ containment: '#mockup-canvas' });
+            $z.resizable({ containment: '#mockup-canvas' });
+        });
+    }
+    initZones();
+
+    $('#mockup-form').on('submit', function(){
+        var img = $('#mockup-canvas img')[0];
+        if(!img) return;
+        $('.print-zone').each(function(){
+            var $z = $(this);
+            var f = $z.data('format');
+            var pos = $z.position();
+            var pct = {
+                top: (pos.top / img.offsetHeight * 100).toFixed(2),
+                left: (pos.left / img.offsetWidth * 100).toFixed(2),
+                width: ($z.width() / img.offsetWidth * 100).toFixed(2),
+                height: ($z.height() / img.offsetHeight * 100).toFixed(2)
+            };
+            $('#area_'+f+'_top').val(pct.top);
+            $('#area_'+f+'_left').val(pct.left);
+            $('#area_'+f+'_width').val(pct.width);
+            $('#area_'+f+'_height').val(pct.height);
+        });
+    });
+});

--- a/includes/init.php
+++ b/includes/init.php
@@ -41,6 +41,11 @@ add_action('admin_enqueue_scripts', function ($hook) {
     if (strpos($hook, 'winshirt') !== false) {
         wp_enqueue_style('winshirt-admin', WINSHIRT_URL . 'assets/css/winshirt-admin.css', [], '1.0');
         wp_enqueue_script('winshirt-admin', WINSHIRT_URL . 'assets/js/winshirt-admin.js', ['wp-element'], '1.0', true);
+
+        if (strpos($hook, 'winshirt-mockups') !== false) {
+            wp_enqueue_style('winshirt-mockups', WINSHIRT_URL . 'assets/css/winshirt-mockups.css', [], '1.0');
+            wp_enqueue_script('winshirt-mockups', WINSHIRT_URL . 'assets/js/winshirt-mockups.js', ['jquery', 'jquery-ui-draggable', 'jquery-ui-resizable'], '1.0', true);
+        }
     }
 });
 

--- a/includes/pages/mockups.php
+++ b/includes/pages/mockups.php
@@ -4,19 +4,21 @@ defined('ABSPATH') || exit;
 function winshirt_page_mockups() {
     $editing = null;
 
-    // Handle deletion
     if (isset($_GET['delete']) && isset($_GET['_wpnonce']) && wp_verify_nonce($_GET['_wpnonce'], 'delete_mockup_' . absint($_GET['delete']))) {
         wp_delete_post(absint($_GET['delete']), true);
         echo '<div class="updated"><p>' . esc_html__('Mockup supprime.', 'winshirt') . '</p></div>';
     }
 
-    // Handle edit request
     if (isset($_GET['edit'])) {
         $editing = get_post(absint($_GET['edit']));
+    } elseif (isset($_GET['add'])) {
+        $editing = (object) ['ID' => 0];
     }
 
-    // Handle form submission
     if (isset($_POST['winshirt_mockup_nonce']) && wp_verify_nonce($_POST['winshirt_mockup_nonce'], 'save_winshirt_mockup')) {
+        require_once ABSPATH . 'wp-admin/includes/file.php';
+        require_once ABSPATH . 'wp-admin/includes/image.php';
+
         $mockup_id = isset($_POST['mockup_id']) ? absint($_POST['mockup_id']) : 0;
 
         $data = [
@@ -32,36 +34,78 @@ function winshirt_page_mockups() {
             $mockup_id = wp_insert_post($data);
         }
 
-        update_post_meta($mockup_id, '_winshirt_product_type', sanitize_text_field($_POST['product_type'] ?? ''));
-        update_post_meta($mockup_id, '_winshirt_side', in_array($_POST['side'] ?? 'front', ['front', 'back'], true) ? $_POST['side'] : 'front');
-        update_post_meta($mockup_id, '_winshirt_format', sanitize_text_field($_POST['format'] ?? ''));
+        update_post_meta($mockup_id, '_winshirt_category', sanitize_text_field($_POST['category'] ?? ''));
 
-        $area = [
-            'x' => floatval($_POST['area_x'] ?? 0),
-            'y' => floatval($_POST['area_y'] ?? 0),
-            'w' => floatval($_POST['area_w'] ?? 0),
-            'h' => floatval($_POST['area_h'] ?? 0),
-        ];
-        update_post_meta($mockup_id, '_winshirt_area', $area);
-
-        $families = isset($_POST['families']) ? array_map('intval', (array) $_POST['families']) : [];
-        update_post_meta($mockup_id, '_winshirt_families', $families);
-
-        if (!empty($_FILES['image']['tmp_name'])) {
-            require_once ABSPATH . 'wp-admin/includes/file.php';
-            require_once ABSPATH . 'wp-admin/includes/image.php';
-            $attachment_id = media_handle_upload('image', 0);
-            if (!is_wp_error($attachment_id)) {
-                set_post_thumbnail($mockup_id, $attachment_id);
+        if (!empty($_FILES['front_image']['tmp_name'])) {
+            $front_id = media_handle_upload('front_image', 0);
+            if (!is_wp_error($front_id)) {
+                update_post_meta($mockup_id, '_winshirt_front_image', $front_id);
             }
         }
+
+        if (!empty($_FILES['back_image']['tmp_name'])) {
+            $back_id = media_handle_upload('back_image', 0);
+            if (!is_wp_error($back_id)) {
+                update_post_meta($mockup_id, '_winshirt_back_image', $back_id);
+            }
+        }
+
+        // Colors
+        $colors = [];
+        if (!empty($_POST['colors']) && is_array($_POST['colors'])) {
+            foreach ((array) $_POST['colors'] as $idx => $cdata) {
+                if (isset($cdata['remove']) && $cdata['remove']) {
+                    continue;
+                }
+                $c = [
+                    'name' => sanitize_text_field($cdata['name'] ?? ''),
+                    'code' => sanitize_text_field($cdata['code'] ?? ''),
+                    'front' => 0,
+                    'back'  => 0,
+                ];
+                if (!empty($_FILES['color_front_' . $idx]['tmp_name'])) {
+                    $fid = media_handle_upload('color_front_' . $idx, 0);
+                    if (!is_wp_error($fid)) {
+                        $c['front'] = $fid;
+                    }
+                } elseif (!empty($cdata['front'])) {
+                    $c['front'] = absint($cdata['front']);
+                }
+                if (!empty($_FILES['color_back_' . $idx]['tmp_name'])) {
+                    $bid = media_handle_upload('color_back_' . $idx, 0);
+                    if (!is_wp_error($bid)) {
+                        $c['back'] = $bid;
+                    }
+                } elseif (!empty($cdata['back'])) {
+                    $c['back'] = absint($cdata['back']);
+                }
+                if ($c['name']) {
+                    $colors[] = $c;
+                }
+            }
+        }
+        update_post_meta($mockup_id, '_winshirt_colors', $colors);
+
+        $areas = [];
+        foreach (['A3', 'A4', 'A5', 'A6', 'A7'] as $fmt) {
+            $areas[$fmt] = [
+                'top'    => floatval($_POST['area_' . $fmt . '_top'] ?? 0),
+                'left'   => floatval($_POST['area_' . $fmt . '_left'] ?? 0),
+                'width'  => floatval($_POST['area_' . $fmt . '_width'] ?? 0),
+                'height' => floatval($_POST['area_' . $fmt . '_height'] ?? 0),
+            ];
+        }
+        update_post_meta($mockup_id, '_winshirt_print_areas', $areas);
 
         echo '<div class="updated"><p>' . esc_html__('Mockup enregistre.', 'winshirt') . '</p></div>';
         $editing = get_post($mockup_id);
     }
 
-    $mockups    = get_posts(['post_type' => 'winshirt_mockup', 'numberposts' => -1, 'orderby' => 'title']);
-    $categories = get_terms(['taxonomy' => 'product_cat', 'hide_empty' => false]);
+    $mockups = get_posts([
+        'post_type'   => 'winshirt_mockup',
+        'numberposts' => -1,
+        'orderby'     => 'title',
+    ]);
 
     echo '<div class="wrap"><h1>' . esc_html__('Gestion des mockups', 'winshirt') . '</h1>';
     include WINSHIRT_PATH . 'templates/admin/partials/mockups-list.php';

--- a/templates/admin/partials/mockups-list.php
+++ b/templates/admin/partials/mockups-list.php
@@ -1,122 +1,121 @@
 <?php
 /**
- * Admin mockup management interface.
- * Variables: $mockups, $editing, $categories
+ * Advanced mockup management interface.
+ * Variables: $mockups, $editing
  */
 ?>
-<h2><?php esc_html_e('Liste des mockups', 'winshirt'); ?></h2>
+<p><a href="<?php echo esc_url(add_query_arg(['page'=>'winshirt-mockups','add'=>1], admin_url('admin.php'))); ?>" class="button button-primary"><?php esc_html_e('Ajouter un mockup', 'winshirt'); ?></a></p>
 <table class="widefat fixed">
     <thead>
         <tr>
-            <th><?php esc_html_e('Titre', 'winshirt'); ?></th>
-            <th><?php esc_html_e('Type', 'winshirt'); ?></th>
-            <th><?php esc_html_e('Recto/Verso', 'winshirt'); ?></th>
-            <th><?php esc_html_e('Format', 'winshirt'); ?></th>
-            <th><?php esc_html_e('Aperçu', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Nom du mockup', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Catégorie', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Couleurs', 'winshirt'); ?></th>
             <th><?php esc_html_e('Actions', 'winshirt'); ?></th>
         </tr>
     </thead>
     <tbody>
     <?php if ($mockups) : ?>
-        <?php foreach ($mockups as $mockup) : ?>
-            <?php
-                $type   = get_post_meta($mockup->ID, '_winshirt_product_type', true);
-                $side   = get_post_meta($mockup->ID, '_winshirt_side', true);
-                $format = get_post_meta($mockup->ID, '_winshirt_format', true);
-            ?>
+        <?php foreach ($mockups as $m) : ?>
+            <?php $colors = get_post_meta($m->ID, '_winshirt_colors', true); $colors = is_array($colors) ? $colors : []; ?>
             <tr>
-                <td><?php echo esc_html($mockup->post_title); ?></td>
-                <td><?php echo esc_html($type); ?></td>
-                <td><?php echo esc_html($side === 'back' ? 'Verso' : 'Recto'); ?></td>
-                <td><?php echo esc_html($format); ?></td>
-                <td><?php echo get_the_post_thumbnail($mockup->ID, 'thumbnail'); ?></td>
+                <td><?php echo esc_html($m->post_title); ?></td>
+                <td><?php echo esc_html(get_post_meta($m->ID, '_winshirt_category', true)); ?></td>
+                <td><?php echo count($colors); ?></td>
                 <td>
-                    <a class="button" href="<?php echo esc_url(add_query_arg(['page' => 'winshirt-mockups', 'edit' => $mockup->ID], admin_url('admin.php'))); ?>"><?php esc_html_e('Modifier', 'winshirt'); ?></a>
-                    <a class="button delete" href="<?php echo esc_url(wp_nonce_url(add_query_arg(['page' => 'winshirt-mockups', 'delete' => $mockup->ID], admin_url('admin.php')), 'delete_mockup_' . $mockup->ID)); ?>"><?php esc_html_e('Supprimer', 'winshirt'); ?></a>
+                    <a class="button" href="<?php echo esc_url(add_query_arg(['page'=>'winshirt-mockups','edit'=>$m->ID], admin_url('admin.php'))); ?>"><?php esc_html_e('Éditer', 'winshirt'); ?></a>
+                    <a class="button delete" href="<?php echo esc_url(wp_nonce_url(add_query_arg(['page'=>'winshirt-mockups','delete'=>$m->ID], admin_url('admin.php')), 'delete_mockup_' . $m->ID)); ?>"><?php esc_html_e('Supprimer', 'winshirt'); ?></a>
                 </td>
             </tr>
         <?php endforeach; ?>
     <?php else : ?>
-        <tr><td colspan="6"><?php esc_html_e('Aucun mockup', 'winshirt'); ?></td></tr>
+        <tr><td colspan="4"><?php esc_html_e('Aucun mockup', 'winshirt'); ?></td></tr>
     <?php endif; ?>
     </tbody>
 </table>
-
-<hr/>
-
-<h2><?php echo $editing ? esc_html__('Modifier le mockup', 'winshirt') : esc_html__('Ajouter un mockup', 'winshirt'); ?></h2>
-<form method="post" enctype="multipart/form-data">
+<?php if ($editing !== null) : ?>
+<hr />
+<h2><?php echo $editing && $editing->ID ? esc_html__('Modifier le mockup', 'winshirt') : esc_html__('Ajouter un mockup', 'winshirt'); ?></h2>
+<form method="post" enctype="multipart/form-data" id="mockup-form">
     <?php wp_nonce_field('save_winshirt_mockup', 'winshirt_mockup_nonce'); ?>
-    <input type="hidden" name="mockup_id" value="<?php echo esc_attr($editing->ID ?? 0); ?>" />
+    <input type="hidden" name="mockup_id" value="<?php echo esc_attr($editing->ID); ?>" />
+    <h3><?php esc_html_e('Informations générales', 'winshirt'); ?></h3>
     <table class="form-table">
         <tr>
-            <th scope="row"><label for="mockup-title">Titre</label></th>
-            <td><input name="title" id="mockup-title" type="text" class="regular-text" value="<?php echo esc_attr($editing->post_title ?? ''); ?>" required /></td>
+            <th><label for="mockup-title"><?php esc_html_e('Nom du mockup', 'winshirt'); ?></label></th>
+            <td><input type="text" id="mockup-title" name="title" class="regular-text" value="<?php echo esc_attr($editing->post_title ?? ''); ?>" required /></td>
         </tr>
         <tr>
-            <th scope="row">Image</th>
+            <th><label for="category"><?php esc_html_e('Catégorie produit', 'winshirt'); ?></label></th>
+            <td><input type="text" id="category" name="category" value="<?php echo esc_attr(get_post_meta($editing->ID, '_winshirt_category', true)); ?>" /></td>
+        </tr>
+        <tr>
+            <th><?php esc_html_e('Image recto', 'winshirt'); ?></th>
             <td>
-                <input type="file" name="image" />
-                <?php if ($editing && has_post_thumbnail($editing->ID)) { echo get_the_post_thumbnail($editing->ID, 'thumbnail'); } ?>
+                <input type="file" name="front_image" />
+                <?php $front = $editing->ID ? get_post_meta($editing->ID, '_winshirt_front_image', true) : ''; if ($front) echo wp_get_attachment_image($front, 'thumbnail'); ?>
             </td>
         </tr>
         <tr>
-            <th scope="row"><label for="product-type">Type de produit</label></th>
+            <th><?php esc_html_e('Image verso', 'winshirt'); ?></th>
             <td>
-                <select name="product_type" id="product-type">
-                    <?php $types = ['T-Shirt','Polo','Casquette','Sweat'];
-                    $current_type = $editing ? get_post_meta($editing->ID, '_winshirt_product_type', true) : '';
-                    foreach ($types as $t) {
-                        echo '<option value="' . esc_attr($t) . '" ' . selected($current_type, $t, false) . '>' . esc_html($t) . '</option>';
-                    } ?>
-                </select>
-            </td>
-        </tr>
-        <tr>
-            <th scope="row"><label for="format">Format impression</label></th>
-            <td>
-                <select name="format" id="format">
-                    <?php $formats = ['A3','A4','A5','A6','A7'];
-                    $current_format = $editing ? get_post_meta($editing->ID, '_winshirt_format', true) : '';
-                    foreach ($formats as $f) {
-                        echo '<option value="' . esc_attr($f) . '" ' . selected($current_format, $f, false) . '>' . esc_html($f) . '</option>';
-                    } ?>
-                </select>
-            </td>
-        </tr>
-        <tr>
-            <th scope="row">Recto/Verso</th>
-            <td>
-                <?php $current_side = $editing ? get_post_meta($editing->ID, '_winshirt_side', true) : 'front'; ?>
-                <label><input type="radio" name="side" value="front" <?php checked($current_side, 'front'); ?> /> <?php esc_html_e('Recto', 'winshirt'); ?></label>
-                <label style="margin-left:10px;"><input type="radio" name="side" value="back" <?php checked($current_side, 'back'); ?> /> <?php esc_html_e('Verso', 'winshirt'); ?></label>
-            </td>
-        </tr>
-        <?php $area = $editing ? get_post_meta($editing->ID, '_winshirt_area', true) : ['x'=>'','y'=>'','w'=>'','h'=>''];
-              $area = is_array($area) ? $area : ['x'=>'','y'=>'','w'=>'','h'=>'']; ?>
-        <tr>
-            <th scope="row">Zone d'impression</th>
-            <td>
-                X <input type="number" step="0.01" name="area_x" value="<?php echo esc_attr($area['x']); ?>" style="width:70px;" />
-                Y <input type="number" step="0.01" name="area_y" value="<?php echo esc_attr($area['y']); ?>" style="width:70px;" />
-                <?php esc_html_e('Largeur', 'winshirt'); ?> <input type="number" step="0.01" name="area_w" value="<?php echo esc_attr($area['w']); ?>" style="width:70px;" />
-                <?php esc_html_e('Hauteur', 'winshirt'); ?> <input type="number" step="0.01" name="area_h" value="<?php echo esc_attr($area['h']); ?>" style="width:70px;" />
-            </td>
-        </tr>
-        <tr>
-            <th scope="row"><label for="families">Familles de produits</label></th>
-            <td>
-                <?php $current_families = $editing ? get_post_meta($editing->ID, '_winshirt_families', true) : [];
-                $current_families = is_array($current_families) ? $current_families : []; ?>
-                <select name="families[]" id="families" multiple size="5">
-                    <?php foreach ($categories as $cat) {
-                        echo '<option value="' . esc_attr($cat->term_id) . '" ' . selected(in_array($cat->term_id, $current_families), true, false) . '>' . esc_html($cat->name) . '</option>';
-                    } ?>
-                </select>
+                <input type="file" name="back_image" />
+                <?php $back = $editing->ID ? get_post_meta($editing->ID, '_winshirt_back_image', true) : ''; if ($back) echo wp_get_attachment_image($back, 'thumbnail'); ?>
             </td>
         </tr>
     </table>
+    <h3><?php esc_html_e('Variantes de couleurs', 'winshirt'); ?></h3>
+    <div id="colors-container">
+        <?php
+        $colors = $editing->ID ? get_post_meta($editing->ID, '_winshirt_colors', true) : [];
+        $colors = is_array($colors) ? $colors : [];
+        $index = 0;
+        foreach ($colors as $c) : ?>
+            <div class="color-row">
+                <button class="remove-color button">&times;</button>
+                <input type="hidden" name="colors[<?php echo $index; ?>][front]" value="<?php echo esc_attr($c['front']); ?>" />
+                <input type="hidden" name="colors[<?php echo $index; ?>][back]" value="<?php echo esc_attr($c['back']); ?>" />
+                <label><?php esc_html_e('Nom', 'winshirt'); ?> <input type="text" name="colors[<?php echo $index; ?>][name]" value="<?php echo esc_attr($c['name']); ?>" /></label>
+                <label><?php esc_html_e('Code', 'winshirt'); ?> <input type="color" name="colors[<?php echo $index; ?>][code]" value="<?php echo esc_attr($c['code']); ?>" /></label>
+                <label><?php esc_html_e('Image recto', 'winshirt'); ?> <input type="file" name="color_front_<?php echo $index; ?>" /><?php if ($c['front']) echo wp_get_attachment_image($c['front'], 'thumbnail'); ?></label>
+                <label><?php esc_html_e('Image verso', 'winshirt'); ?> <input type="file" name="color_back_<?php echo $index; ?>" /><?php if ($c['back']) echo wp_get_attachment_image($c['back'], 'thumbnail'); ?></label>
+            </div>
+        <?php $index++; endforeach; ?>
+    </div>
+    <p><a href="#" id="add-color" class="button"><?php esc_html_e('Ajouter une couleur', 'winshirt'); ?></a></p>
+    <script type="text/template" id="color-template">
+        <div class="color-row">
+            <button class="remove-color button">&times;</button>
+            <input type="hidden" name="colors[%i%][front]" value="" />
+            <input type="hidden" name="colors[%i%][back]" value="" />
+            <label><?php esc_html_e('Nom', 'winshirt'); ?> <input type="text" name="colors[%i%][name]" value="" /></label>
+            <label><?php esc_html_e('Code', 'winshirt'); ?> <input type="color" name="colors[%i%][code]" value="#000000" /></label>
+            <label><?php esc_html_e('Image recto', 'winshirt'); ?> <input type="file" name="color_front_%i%" /></label>
+            <label><?php esc_html_e('Image verso', 'winshirt'); ?> <input type="file" name="color_back_%i%" /></label>
+        </div>
+    </script>
+    <h3><?php esc_html_e('Zones d\'impression', 'winshirt'); ?></h3>
+    <div id="print-zone-wrapper">
+        <div id="mockup-canvas">
+            <?php if ($front) { echo wp_get_attachment_image($front, 'medium'); } ?>
+            <?php
+            $areas = $editing->ID ? get_post_meta($editing->ID, '_winshirt_print_areas', true) : [];
+            $areas = is_array($areas) ? $areas : [];
+            foreach (['A3','A4','A5','A6','A7'] as $fmt) {
+                $a = $areas[$fmt] ?? ['top'=>10,'left'=>10,'width'=>20,'height'=>20];
+                echo '<div class="print-zone" data-format="'.$fmt.'" style="top:'.$a['top'].'%;left:'.$a['left'].'%;width:'.$a['width'].'%;height:'.$a['height'].'%;">'.$fmt.'</div>';
+            }
+            ?>
+        </div>
+    </div>
+    <?php foreach (['A3','A4','A5','A6','A7'] as $fmt) : $a = $areas[$fmt] ?? ['top'=>0,'left'=>0,'width'=>0,'height'=>0]; ?>
+        <input type="hidden" id="area_<?php echo $fmt; ?>_top" name="area_<?php echo $fmt; ?>_top" value="<?php echo esc_attr($a['top']); ?>" />
+        <input type="hidden" id="area_<?php echo $fmt; ?>_left" name="area_<?php echo $fmt; ?>_left" value="<?php echo esc_attr($a['left']); ?>" />
+        <input type="hidden" id="area_<?php echo $fmt; ?>_width" name="area_<?php echo $fmt; ?>_width" value="<?php echo esc_attr($a['width']); ?>" />
+        <input type="hidden" id="area_<?php echo $fmt; ?>_height" name="area_<?php echo $fmt; ?>_height" value="<?php echo esc_attr($a['height']); ?>" />
+    <?php endforeach; ?>
     <p>
-        <input type="submit" class="button button-primary" value="<?php echo $editing ? esc_attr__('Mettre à jour', 'winshirt') : esc_attr__('Ajouter mockup', 'winshirt'); ?>" />
+        <input type="submit" class="button button-primary" value="<?php echo $editing && $editing->ID ? esc_attr__('Mettre à jour', 'winshirt') : esc_attr__('Enregistrer', 'winshirt'); ?>" />
     </p>
 </form>
+<?php endif; ?>


### PR DESCRIPTION
## Summary
- load extra assets for mockup editor
- implement advanced mockup page storing colors and print zones
- add admin scripts and styles

## Testing
- `php -l includes/pages/mockups.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68512749a4d4832997e29af470599a4d