### PR TITLE
Modernize customization modal

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -1,16 +1,34 @@
-#winshirt-modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.8);z-index:9999;align-items:center;justify-content:center;}
-#winshirt-modal.open{display:flex;}
-#winshirt-modal .winshirt-modal-content{background:#fff;width:90%;max-width:900px;max-height:90%;overflow:auto;padding:20px;position:relative;border-radius:4px;display:flex;flex-direction:column;}
-#winshirt-modal .winshirt-close{position:absolute;top:10px;right:15px;font-size:24px;cursor:pointer;}
-.winshirt-tab-links{list-style:none;padding:0;margin:0 0 10px;display:flex;flex-wrap:wrap;}
-.winshirt-tab-links li{margin-right:5px;}
-.winshirt-tab-links li a{display:block;padding:8px 12px;background:#eee;text-decoration:none;color:#000;border-radius:3px;}
-.winshirt-tab-links li.active a{background:#ddd;}
-.winshirt-tab{display:none;}
-.winshirt-tab.active{display:block;}
-.winshirt-upload{float:right;}
-.winshirt-preview{text-align:center;margin-top:20px;}
-.winshirt-preview img{max-width:250px;}
-.winshirt-preview-buttons{text-align:center;margin-bottom:10px;}
-@media(max-width:600px){#winshirt-modal .winshirt-modal-content{width:100%;height:100%;max-height:100%;border-radius:0;}}
-.winshirt-text{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);font-size:24px;color:#000;}
+/* WinShirt product customizer - glassmorphism style */
+.ws-modal{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.6);backdrop-filter:blur(6px);z-index:9999}
+.hidden{display:none}
+.ws-modal.hidden{display:none}
+.ws-modal-content{position:relative;width:100%;max-width:960px;background:rgba(255,255,255,0.1);backdrop-filter:blur(16px) saturate(180%);border:1px solid rgba(255,255,255,0.2);border-radius:1rem;box-shadow:0 10px 25px rgba(0,0,0,0.3);padding:1.5rem;color:#fff;overflow:hidden}
+@media(max-width:640px){.ws-modal-content{height:100%;max-width:none;border-radius:0}}
+.ws-close{background:rgba(255,255,255,0.1);padding:.25rem .75rem;border:1px solid rgba(255,255,255,0.2);border-radius:.375rem;cursor:pointer;transition:background .2s}
+.ws-close:hover{background:rgba(255,255,255,0.2)}
+.ws-tabs-header{display:flex;gap:.5rem;margin-bottom:1rem;border-bottom:1px solid rgba(255,255,255,0.1);padding-bottom:.5rem}
+.ws-tab-button{padding:.5rem 1rem;border-radius:.5rem;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.2);cursor:pointer;transition:background .3s}
+.ws-ml-auto{margin-left:auto}
+.ws-tab-button:hover,.ws-tab-button.active{background:rgba(255,255,255,0.2)}
+.ws-tab-content{display:none;animation:wsFade .3s ease}
+.ws-tab-content.active{display:block}
+@keyframes wsFade{from{opacity:0}to{opacity:1}}
+.ws-textarea{width:100%;min-height:100px;border-radius:.5rem;padding:.75rem;color:#000;resize:none}
+.ws-upload-btn{margin-top:1rem;padding:.5rem 1rem;background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.2);border-radius:.5rem;color:#fff;cursor:pointer}
+.ws-upload-btn:hover{background:rgba(255,255,255,0.2)}
+.ws-gallery{display:flex;flex-wrap:wrap;gap:.5rem}
+.ws-preview{position:relative;margin-top:1.5rem;width:100%;aspect-ratio:4/5;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.2);border-radius:.5rem;overflow:hidden;display:flex;align-items:center;justify-content:center}
+.ws-preview-img{max-width:100%;max-height:100%;object-fit:contain}
+.ws-design-zone{position:absolute;top:30%;left:25%;width:200px;height:150px;border:2px dashed #60a5fa;background:rgba(255,255,255,0.2);border-radius:.25rem;cursor:move}
+.ws-handle{position:absolute;width:10px;height:10px;background:#60a5fa;border-radius:50%}
+.ws-handle-nw{top:-5px;left:-5px;cursor:nwse-resize}
+.ws-handle-ne{top:-5px;right:-5px;cursor:nesw-resize}
+.ws-handle-sw{bottom:-5px;left:-5px;cursor:nesw-resize}
+.ws-handle-se{bottom:-5px;right:-5px;cursor:nwse-resize}
+.ws-remove{position:absolute;top:-12px;right:-12px;width:24px;height:24px;border-radius:50%;background:#ef4444;color:#fff;font-weight:bold;border:none;cursor:pointer}
+.ws-actions{display:flex;justify-content:space-between;align-items:center;margin-top:1.5rem}
+.ws-toggle{display:flex;gap:.5rem}
+.ws-side-btn{background:rgba(255,255,255,0.1);padding:.5rem 1rem;border:1px solid rgba(255,255,255,0.2);border-radius:.5rem;color:#fff;cursor:pointer;margin-right:.5rem}
+.ws-side-btn.active,.ws-side-btn:hover{background:rgba(255,255,255,0.2)}
+.ws-validate{background:#22c55e;padding:.5rem 1.5rem;border-radius:.5rem;color:#fff;cursor:pointer}
+.ws-validate:hover{background:#16a34a}

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -1,93 +1,85 @@
 jQuery(function($){
-    var state = JSON.parse(localStorage.getItem('winshirt_state')) || {front:'', back:'', text:'', side:'front'};
+  var $modal = $('#winshirt-customizer-modal');
+  if(!$modal.length) return;
 
-    function saveState(){
-        localStorage.setItem('winshirt_state', JSON.stringify(state));
+  var state = JSON.parse(localStorage.getItem('winshirt_state')) || {front:'', back:'', text:'', side:'front'};
+  var $previewImg = $modal.find('.ws-preview-img');
+
+  function saveState(){
+    localStorage.setItem('winshirt_state', JSON.stringify(state));
+  }
+
+  function loadState(){
+    var frontDefault = $modal.data('default-front') || '';
+    var backDefault  = $modal.data('default-back') || '';
+    if(state.side === 'back'){
+      $('#winshirt-back-btn').addClass('active');
+      $('#winshirt-front-btn').removeClass('active');
+      $previewImg.attr('src', state.back || backDefault);
+    }else{
+      $('#winshirt-front-btn').addClass('active');
+      $('#winshirt-back-btn').removeClass('active');
+      $previewImg.attr('src', state.front || frontDefault);
     }
-
-    function loadState(){
-        var frontDefault = $('#winshirt-modal').data('default-front') || '';
-        var backDefault  = $('#winshirt-modal').data('default-back') || '';
-        if(state.front){
-            $('#winshirt-preview-front img').attr('src', state.front);
-        } else if(frontDefault){
-            $('#winshirt-preview-front img').attr('src', frontDefault);
-        }
-        if(state.back){
-            $('#winshirt-preview-back img').attr('src', state.back);
-        } else if(backDefault){
-            $('#winshirt-preview-back img').attr('src', backDefault);
-        }
-        if(state.text){
-            $('#winshirt-text-input').val(state.text);
-            $('.winshirt-text').text(state.text);
-        }
-        switchSide(state.side || 'front');
+    if(state.text){
+      $('#winshirt-text-input').val(state.text);
     }
+  }
 
-    function switchSide(side){
-        state.side = side;
-        $('#winshirt-preview-front, #winshirt-preview-back').hide();
-        if(side === 'back'){
-            $('#winshirt-preview-back').show();
-        }else{
-            $('#winshirt-preview-front').show();
-        }
-        saveState();
-    }
-
-    $(document).on('click', '#winshirt-open-modal', function(e){
-        e.preventDefault();
-        $('#winshirt-modal').addClass('open');
-    });
-
-    $(document).on('click', '.winshirt-close', function(){
-        $('#winshirt-modal').removeClass('open');
-    });
-
-    $(document).on('click', '.winshirt-tab-links a', function(e){
-        e.preventDefault();
-        var target = $(this).attr('href');
-        $('.winshirt-tab-links li').removeClass('active');
-        $(this).parent().addClass('active');
-        $('.winshirt-tab').removeClass('active');
-        $(target).addClass('active');
-    });
-
-    $(document).on('click', '.winshirt-upload', function(){
-        $(this).next('input[type=file]').trigger('click');
-    });
-
-    $(document).on('change', '.winshirt-upload-input', function(){
-        var side = state.side;
-        var input = this;
-        if(!input.files.length) return;
-        var reader = new FileReader();
-        reader.onload = function(e){
-            if(side === 'back'){
-                $('#winshirt-preview-back img').attr('src', e.target.result);
-                state.back = e.target.result;
-            } else {
-                $('#winshirt-preview-front img').attr('src', e.target.result);
-                state.front = e.target.result;
-            }
-            saveState();
-        };
-        reader.readAsDataURL(input.files[0]);
-    });
-
-    $(document).on('input', '#winshirt-text-input', function(){
-        state.text = $(this).val();
-        $('.winshirt-text').text(state.text);
-        saveState();
-    });
-
-    $(document).on('click', '#winshirt-front-btn', function(){
-        switchSide('front');
-    });
-    $(document).on('click', '#winshirt-back-btn', function(){
-        switchSide('back');
-    });
-
+  function switchSide(side){
+    state.side = side;
     loadState();
+    saveState();
+  }
+
+  $('#winshirt-open-modal').on('click', function(e){
+    e.preventDefault();
+    $modal.removeClass('hidden');
+    loadState();
+  });
+
+  $('#winshirt-close-modal').on('click', function(){
+    $modal.addClass('hidden');
+  });
+
+  $('.ws-tab-button').on('click', function(){
+    var tab = $(this).data('tab');
+    $('.ws-tab-button').removeClass('active');
+    $(this).addClass('active');
+    $('.ws-tab-content').removeClass('active').addClass('hidden');
+    $('#ws-tab-'+tab).addClass('active').removeClass('hidden');
+  });
+
+  $('.ws-upload-btn').on('click', function(){
+    $('#ws-upload-input').trigger('click');
+  });
+
+  $('#ws-upload-input').on('change', function(){
+    var input = this;
+    if(!input.files.length) return;
+    var reader = new FileReader();
+    reader.onload = function(e){
+      if(state.side === 'back'){
+        state.back = e.target.result;
+      }else{
+        state.front = e.target.result;
+      }
+      loadState();
+      saveState();
+    };
+    reader.readAsDataURL(input.files[0]);
+  });
+
+  $('#winshirt-text-input').on('input', function(){
+    state.text = $(this).val();
+    saveState();
+  });
+
+  $('#winshirt-front-btn').on('click', function(){ switchSide('front'); });
+  $('#winshirt-back-btn').on('click', function(){ switchSide('back'); });
+
+  // Draggable + resizable zone
+  $('#design-zone').draggable({containment:'.ws-preview'}).resizable({containment:'.ws-preview'});
+
+  loadState();
 });

--- a/includes/init.php
+++ b/includes/init.php
@@ -5,7 +5,7 @@
 add_action('wp_enqueue_scripts', function () {
     if (is_product()) {
         wp_enqueue_style('winshirt-modal', WINSHIRT_URL . 'assets/css/winshirt-modal.css', [], '1.0');
-        wp_enqueue_script('winshirt-modal', WINSHIRT_URL . 'assets/js/winshirt-modal.js', ['jquery'], '1.0', true);
+        wp_enqueue_script('winshirt-modal', WINSHIRT_URL . 'assets/js/winshirt-modal.js', ['jquery', 'jquery-ui-draggable', 'jquery-ui-resizable'], '1.0', true);
     }
 });
 
@@ -56,9 +56,9 @@ function winshirt_render_customize_button() {
         return;
     }
 
-    $pid        = $product->get_id();
-    $show       = get_post_meta( $pid, '_winshirt_show_button', true );
-    if ( 'yes' !== $show ) {
+    $pid      = $product->get_id();
+    $enabled  = get_post_meta( $pid, '_winshirt_enabled', true );
+    if ( 'yes' !== $enabled ) {
         return;
     }
 
@@ -70,7 +70,7 @@ function winshirt_render_customize_button() {
     echo '<button id="winshirt-open-modal" class="button">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button>';
     $default_front = $front_url;
     $default_back  = $back_url;
-    include WINSHIRT_PATH . 'templates/frontend/modal-personnalisation.php';
+    include WINSHIRT_PATH . 'templates/personalizer-modal.php';
 }
 add_action( 'woocommerce_single_product_summary', 'winshirt_render_customize_button', 35 );
 

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -1,0 +1,49 @@
+<div id="winshirt-customizer-modal" class="ws-modal hidden" data-default-front="<?php echo esc_attr( $default_front ?? '' ); ?>" data-default-back="<?php echo esc_attr( $default_back ?? '' ); ?>">
+  <div class="ws-modal-content">
+    <div class="ws-tabs-header">
+      <button class="ws-tab-button active" data-tab="gallery">🖼 Galerie</button>
+      <button class="ws-tab-button" data-tab="text">🔤 Texte</button>
+      <button class="ws-tab-button" data-tab="ai">🤖 IA</button>
+      <button class="ws-tab-button" data-tab="svg">✒️ SVG</button>
+      <button id="winshirt-close-modal" class="ws-close ws-ml-auto">Fermer ✖️</button>
+    </div>
+
+    <div class="ws-tab-content" id="ws-tab-gallery">
+      <p>Choisissez un design dans la galerie.</p>
+      <div class="ws-gallery"></div>
+      <button class="ws-upload-btn">Uploader un visuel</button>
+      <input type="file" id="ws-upload-input" accept="image/*" class="hidden" />
+    </div>
+
+    <div class="ws-tab-content hidden" id="ws-tab-text">
+      <textarea id="winshirt-text-input" placeholder="Ajoutez votre texte ici..." class="ws-textarea"></textarea>
+    </div>
+
+    <div class="ws-tab-content hidden" id="ws-tab-ai">
+      <p>Générez une image grâce à l’IA (bientôt disponible).</p>
+    </div>
+
+    <div class="ws-tab-content hidden" id="ws-tab-svg">
+      <p>Bibliothèque d’icônes vectorielles (SVG).</p>
+    </div>
+
+    <div class="ws-preview">
+      <img src="<?php echo esc_url( $default_front ?? '' ); ?>" alt="Mockup" class="ws-preview-img" />
+      <div id="design-zone" class="ws-design-zone">
+        <button class="ws-remove" title="Supprimer">×</button>
+        <div class="ws-handle ws-handle-nw"></div>
+        <div class="ws-handle ws-handle-ne"></div>
+        <div class="ws-handle ws-handle-sw"></div>
+        <div class="ws-handle ws-handle-se"></div>
+      </div>
+    </div>
+
+    <div class="ws-actions">
+      <div class="ws-toggle">
+        <button id="winshirt-front-btn" class="ws-side-btn active">Recto</button>
+        <button id="winshirt-back-btn" class="ws-side-btn">Verso</button>
+      </div>
+      <button id="winshirt-validate" class="ws-validate">Valider la personnalisation</button>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- show personalization button only if product is marked as customizable
- enqueue jQuery UI for draggable/resizable features
- add new Tailwind-like glassmorphism styles
- rewrite JS logic for new modal
- replace modal markup with modern responsive design

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68512932763c832994d9278037d52c39