### PR TITLE
Add dynamic print zones

### DIFF
--- a/assets/css/winshirt-mockups.css
+++ b/assets/css/winshirt-mockups.css
@@ -1,5 +1,7 @@
 #colors-container .color-row{margin-bottom:10px;border:1px solid #ddd;padding:10px;position:relative;}
 #colors-container .remove-color{position:absolute;top:4px;right:4px;}
-#print-zone-wrapper{margin-top:15px;}
-#print-zone-wrapper #mockup-canvas{position:relative;display:inline-block;border:1px solid #ccc;}
-#print-zone-wrapper .print-zone{border:2px dashed #f00;position:absolute;background:rgba(255,0,0,0.2);text-align:center;color:#000;}
+#print-zone-wrapper{margin-top:15px;display:flex;gap:20px;flex-wrap:wrap;}
+#print-zone-wrapper .mockup-canvas{position:relative;display:inline-block;border:1px solid #ccc;}
+#print-zone-wrapper .print-zone{border:2px dashed #f00;position:absolute;background:rgba(255,0,0,0.2);text-align:center;color:#000;cursor:move;}
+#zone-controls .zone-row{margin-bottom:10px;border:1px solid #ddd;padding:10px;position:relative;}
+#zone-controls .remove-zone{position:absolute;top:4px;right:4px;}

--- a/assets/js/winshirt-mockups.js
+++ b/assets/js/winshirt-mockups.js
@@ -12,21 +12,76 @@ jQuery(function($){
         $(this).closest('.color-row').remove();
     });
 
-    function initZones(){
-        $('.print-zone').each(function(){
-            var $z = $(this);
-            $z.draggable({ containment: '#mockup-canvas' });
-            $z.resizable({ containment: '#mockup-canvas' });
-        });
+    function initZone($z){
+        var side = $z.data('side');
+        var cont = side === 'back' ? '#mockup-canvas-back' : '#mockup-canvas-front';
+        $z.draggable({ containment: cont });
+        $z.resizable({ containment: cont });
     }
-    initZones();
+
+    function createZone(index){
+        var $row = $('.zone-row[data-index='+index+']');
+        var side = $row.find('.zone-side').val();
+        var fmt = $row.find('.zone-format').val();
+        var top = parseFloat($row.find('.zone-top').val()) || 10;
+        var left = parseFloat($row.find('.zone-left').val()) || 10;
+        var width = parseFloat($row.find('.zone-width').val()) || 20;
+        var height = parseFloat($row.find('.zone-height').val()) || 20;
+        var $canvas = side === 'back' ? $('#mockup-canvas-back') : $('#mockup-canvas-front');
+        var $zone = $('<div class="print-zone" data-index="'+index+'" data-side="'+side+'" data-format="'+fmt+'">'+fmt+'</div>');
+        $zone.css({top:top+'%',left:left+'%',width:width+'%',height:height+'%'});
+        $canvas.append($zone);
+        initZone($zone);
+    }
+
+    function moveZone(index, side){
+        var $zone = $('.print-zone[data-index='+index+']');
+        var cont = side === 'back' ? '#mockup-canvas-back' : '#mockup-canvas-front';
+        $zone.attr('data-side', side).appendTo($(cont));
+        $zone.draggable('option','containment', cont);
+        $zone.resizable('option','containment', cont);
+    }
+
+    $('#add-zone').on('click', function(e){
+        e.preventDefault();
+        var index = $('#zones-container .zone-row').length;
+        var tpl = $('#zone-template').html().replace(/%i%/g, index);
+        $('#zones-container').append(tpl);
+        createZone(index);
+    });
+
+    $(document).on('click', '.remove-zone', function(e){
+        e.preventDefault();
+        var $row = $(this).closest('.zone-row');
+        var idx = $row.data('index');
+        $('.print-zone[data-index='+idx+']').remove();
+        $row.remove();
+    });
+
+    $(document).on('change', '.zone-side', function(){
+        var $row = $(this).closest('.zone-row');
+        moveZone($row.data('index'), $(this).val());
+    });
+
+    $(document).on('change', '.zone-format', function(){
+        var $row = $(this).closest('.zone-row');
+        var idx = $row.data('index');
+        $('.print-zone[data-index='+idx+']').text($(this).val()).attr('data-format', $(this).val());
+    });
+
+    $('.zone-row').each(function(){
+        createZone($(this).data('index'));
+    });
 
     $('#mockup-form').on('submit', function(){
-        var img = $('#mockup-canvas img')[0];
-        if(!img) return;
-        $('.print-zone').each(function(){
-            var $z = $(this);
-            var f = $z.data('format');
+        $('.zone-row').each(function(){
+            var $row = $(this);
+            var idx = $row.data('index');
+            var side = $row.find('.zone-side').val();
+            var $canvas = side === 'back' ? $('#mockup-canvas-back') : $('#mockup-canvas-front');
+            var img = $canvas.find('img')[0];
+            if(!img) return;
+            var $z = $('.print-zone[data-index='+idx+']');
             var pos = $z.position();
             var pct = {
                 top: (pos.top / img.offsetHeight * 100).toFixed(2),
@@ -34,10 +89,10 @@ jQuery(function($){
                 width: ($z.width() / img.offsetWidth * 100).toFixed(2),
                 height: ($z.height() / img.offsetHeight * 100).toFixed(2)
             };
-            $('#area_'+f+'_top').val(pct.top);
-            $('#area_'+f+'_left').val(pct.left);
-            $('#area_'+f+'_width').val(pct.width);
-            $('#area_'+f+'_height').val(pct.height);
+            $row.find('.zone-top').val(pct.top);
+            $row.find('.zone-left').val(pct.left);
+            $row.find('.zone-width').val(pct.width);
+            $row.find('.zone-height').val(pct.height);
         });
     });
 });

--- a/includes/pages/mockups.php
+++ b/includes/pages/mockups.php
@@ -86,16 +86,24 @@ function winshirt_page_mockups() {
         }
         update_post_meta($mockup_id, '_winshirt_colors', $colors);
 
-        $areas = [];
-        foreach (['A3', 'A4', 'A5', 'A6', 'A7'] as $fmt) {
-            $areas[$fmt] = [
-                'top'    => floatval($_POST['area_' . $fmt . '_top'] ?? 0),
-                'left'   => floatval($_POST['area_' . $fmt . '_left'] ?? 0),
-                'width'  => floatval($_POST['area_' . $fmt . '_width'] ?? 0),
-                'height' => floatval($_POST['area_' . $fmt . '_height'] ?? 0),
-            ];
+        $zones = [];
+        if (!empty($_POST['zones']) && is_array($_POST['zones'])) {
+            foreach ((array) $_POST['zones'] as $z) {
+                if (empty($z['name'])) {
+                    continue;
+                }
+                $zones[] = [
+                    'name'   => sanitize_text_field($z['name']),
+                    'format' => in_array($z['format'], ['A3','A4','A5','A6','A7']) ? $z['format'] : 'A4',
+                    'side'   => $z['side'] === 'back' ? 'back' : 'front',
+                    'top'    => floatval($z['top'] ?? 0),
+                    'left'   => floatval($z['left'] ?? 0),
+                    'width'  => floatval($z['width'] ?? 0),
+                    'height' => floatval($z['height'] ?? 0),
+                ];
+            }
         }
-        update_post_meta($mockup_id, '_winshirt_print_areas', $areas);
+        update_post_meta($mockup_id, '_winshirt_print_zones', $zones);
 
         echo '<div class="updated"><p>' . esc_html__('Mockup enregistre.', 'winshirt') . '</p></div>';
         $editing = get_post($mockup_id);

--- a/templates/admin/partials/mockups-list.php
+++ b/templates/admin/partials/mockups-list.php
@@ -95,25 +95,72 @@
         </div>
     </script>
     <h3><?php esc_html_e('Zones d\'impression', 'winshirt'); ?></h3>
+    <?php
+        $zones = $editing->ID ? get_post_meta($editing->ID, '_winshirt_print_zones', true) : [];
+        $zones = is_array($zones) ? $zones : [];
+    ?>
+    <div id="zone-controls">
+        <div id="zones-container">
+        <?php $zindex = 0; foreach ($zones as $z) : ?>
+            <div class="zone-row" data-index="<?php echo $zindex; ?>">
+                <button class="remove-zone button">&times;</button>
+                <label><?php esc_html_e('Nom', 'winshirt'); ?> <input type="text" name="zones[<?php echo $zindex; ?>][name]" value="<?php echo esc_attr($z['name']); ?>" /></label>
+                <label><?php esc_html_e('Format', 'winshirt'); ?>
+                    <select name="zones[<?php echo $zindex; ?>][format]" class="zone-format">
+                        <?php foreach(['A3','A4','A5','A6','A7'] as $fmt) echo '<option value="'.$fmt.'" '.selected($z['format'],$fmt,false).'>'.$fmt.'</option>'; ?>
+                    </select>
+                </label>
+                <label><?php esc_html_e('Face', 'winshirt'); ?>
+                    <select name="zones[<?php echo $zindex; ?>][side]" class="zone-side">
+                        <option value="front" <?php selected($z['side'],'front'); ?>><?php esc_html_e('Recto','winshirt'); ?></option>
+                        <option value="back" <?php selected($z['side'],'back'); ?>><?php esc_html_e('Verso','winshirt'); ?></option>
+                    </select>
+                </label>
+                <input type="hidden" name="zones[<?php echo $zindex; ?>][top]" class="zone-top" value="<?php echo esc_attr($z['top']); ?>" />
+                <input type="hidden" name="zones[<?php echo $zindex; ?>][left]" class="zone-left" value="<?php echo esc_attr($z['left']); ?>" />
+                <input type="hidden" name="zones[<?php echo $zindex; ?>][width]" class="zone-width" value="<?php echo esc_attr($z['width']); ?>" />
+                <input type="hidden" name="zones[<?php echo $zindex; ?>][height]" class="zone-height" value="<?php echo esc_attr($z['height']); ?>" />
+            </div>
+        <?php $zindex++; endforeach; ?>
+        </div>
+        <p><a href="#" id="add-zone" class="button"><?php esc_html_e('Ajouter une zone', 'winshirt'); ?></a></p>
+    </div>
+    <script type="text/template" id="zone-template">
+        <div class="zone-row" data-index="%i%">
+            <button class="remove-zone button">&times;</button>
+            <label><?php esc_html_e('Nom', 'winshirt'); ?> <input type="text" name="zones[%i%][name]" /></label>
+            <label><?php esc_html_e('Format', 'winshirt'); ?>
+                <select name="zones[%i%][format]" class="zone-format">
+                    <option value="A3">A3</option>
+                    <option value="A4" selected>A4</option>
+                    <option value="A5">A5</option>
+                    <option value="A6">A6</option>
+                    <option value="A7">A7</option>
+                </select>
+            </label>
+            <label><?php esc_html_e('Face', 'winshirt'); ?>
+                <select name="zones[%i%][side]" class="zone-side">
+                    <option value="front"><?php esc_html_e('Recto','winshirt'); ?></option>
+                    <option value="back"><?php esc_html_e('Verso','winshirt'); ?></option>
+                </select>
+            </label>
+            <input type="hidden" name="zones[%i%][top]" class="zone-top" value="10" />
+            <input type="hidden" name="zones[%i%][left]" class="zone-left" value="10" />
+            <input type="hidden" name="zones[%i%][width]" class="zone-width" value="20" />
+            <input type="hidden" name="zones[%i%][height]" class="zone-height" value="20" />
+        </div>
+    </script>
+
     <div id="print-zone-wrapper">
-        <div id="mockup-canvas">
+        <div id="mockup-canvas-front" class="mockup-canvas">
             <?php if ($front) { echo wp_get_attachment_image($front, 'medium'); } ?>
-            <?php
-            $areas = $editing->ID ? get_post_meta($editing->ID, '_winshirt_print_areas', true) : [];
-            $areas = is_array($areas) ? $areas : [];
-            foreach (['A3','A4','A5','A6','A7'] as $fmt) {
-                $a = $areas[$fmt] ?? ['top'=>10,'left'=>10,'width'=>20,'height'=>20];
-                echo '<div class="print-zone" data-format="'.$fmt.'" style="top:'.$a['top'].'%;left:'.$a['left'].'%;width:'.$a['width'].'%;height:'.$a['height'].'%;">'.$fmt.'</div>';
-            }
-            ?>
+            <?php foreach ($zones as $i => $z) { if ($z['side'] !== 'front') continue; echo '<div class="print-zone" data-index="'.$i.'" data-side="front" data-format="'.$z['format'].'" style="top:'.$z['top'].'%;left:'.$z['left'].'%;width:'.$z['width'].'%;height:'.$z['height'].'%;">'.$z['format'].'</div>'; } ?>
+        </div>
+        <div id="mockup-canvas-back" class="mockup-canvas">
+            <?php if ($back) { echo wp_get_attachment_image($back, 'medium'); } ?>
+            <?php foreach ($zones as $i => $z) { if ($z['side'] !== 'back') continue; echo '<div class="print-zone" data-index="'.$i.'" data-side="back" data-format="'.$z['format'].'" style="top:'.$z['top'].'%;left:'.$z['left'].'%;width:'.$z['width'].'%;height:'.$z['height'].'%;">'.$z['format'].'</div>'; } ?>
         </div>
     </div>
-    <?php foreach (['A3','A4','A5','A6','A7'] as $fmt) : $a = $areas[$fmt] ?? ['top'=>0,'left'=>0,'width'=>0,'height'=>0]; ?>
-        <input type="hidden" id="area_<?php echo $fmt; ?>_top" name="area_<?php echo $fmt; ?>_top" value="<?php echo esc_attr($a['top']); ?>" />
-        <input type="hidden" id="area_<?php echo $fmt; ?>_left" name="area_<?php echo $fmt; ?>_left" value="<?php echo esc_attr($a['left']); ?>" />
-        <input type="hidden" id="area_<?php echo $fmt; ?>_width" name="area_<?php echo $fmt; ?>_width" value="<?php echo esc_attr($a['width']); ?>" />
-        <input type="hidden" id="area_<?php echo $fmt; ?>_height" name="area_<?php echo $fmt; ?>_height" value="<?php echo esc_attr($a['height']); ?>" />
-    <?php endforeach; ?>
     <p>
         <input type="submit" class="button button-primary" value="<?php echo $editing && $editing->ID ? esc_attr__('Mettre à jour', 'winshirt') : esc_attr__('Enregistrer', 'winshirt'); ?>" />
     </p>


### PR DESCRIPTION
## Summary
- support storing multiple print zones per mockup
- allow choosing side, format and name
- manage zone rectangles on separate front/back canvases
- update styles for new editor layout

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68512d1324648329b37fce41d198c5e9