### PR TITLE
Amélioration du modal de personnalisation

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -19,12 +19,10 @@
 .ws-gallery{display:flex;flex-wrap:wrap;gap:.5rem}
 .ws-preview{position:relative;margin-top:1.5rem;width:100%;aspect-ratio:4/5;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.2);border-radius:.5rem;overflow:hidden;display:flex;align-items:center;justify-content:center}
 .ws-preview-img{max-width:100%;max-height:100%;object-fit:contain}
-.ws-design-zone{position:absolute;top:30%;left:25%;width:200px;height:150px;border:2px dashed #60a5fa;background:rgba(255,255,255,0.2);border-radius:.25rem;cursor:move}
-.ws-handle{position:absolute;width:10px;height:10px;background:#60a5fa;border-radius:50%}
-.ws-handle-nw{top:-5px;left:-5px;cursor:nwse-resize}
-.ws-handle-ne{top:-5px;right:-5px;cursor:nesw-resize}
-.ws-handle-sw{bottom:-5px;left:-5px;cursor:nesw-resize}
-.ws-handle-se{bottom:-5px;right:-5px;cursor:nwse-resize}
+.ws-canvas{position:absolute;inset:0}
+.ws-item{position:absolute;border:2px dashed #60a5fa;background:rgba(255,255,255,0.2);border-radius:.25rem;cursor:move}
+.ws-item img{width:100%;height:100%;object-fit:contain;display:block}
+.ws-item .ws-text{display:block;width:100%;height:100%;color:#000;text-align:center;word-break:break-word}
 .ws-remove{position:absolute;top:-12px;right:-12px;width:24px;height:24px;border-radius:50%;background:#ef4444;color:#fff;font-weight:bold;border:none;cursor:pointer}
 .ws-actions{display:flex;justify-content:space-between;align-items:center;margin-top:1.5rem}
 .ws-toggle{display:flex;gap:.5rem}

--- a/includes/init.php
+++ b/includes/init.php
@@ -56,14 +56,18 @@ function winshirt_render_customize_button() {
         return;
     }
 
-    $pid      = $product->get_id();
-    $enabled  = get_post_meta( $pid, '_winshirt_enabled', true );
-    if ( 'yes' !== $enabled ) {
+    $pid            = $product->get_id();
+    $enabled        = get_post_meta( $pid, '_winshirt_enabled', true ) === 'yes';
+    $show_button    = get_post_meta( $pid, '_winshirt_show_button', true ) === 'yes';
+    $front_id       = absint( get_post_meta( $pid, '_winshirt_default_mockup_front', true ) );
+    $back_id        = absint( get_post_meta( $pid, '_winshirt_default_mockup_back', true ) );
+    $mockups_raw    = get_post_meta( $pid, '_winshirt_mockups', true );
+    $has_mockup     = $front_id || $back_id || ! empty( $mockups_raw );
+
+    if ( ! $enabled || ! $show_button || ! $has_mockup ) {
         return;
     }
 
-    $front_id   = absint( get_post_meta( $pid, '_winshirt_default_mockup_front', true ) );
-    $back_id    = absint( get_post_meta( $pid, '_winshirt_default_mockup_back', true ) );
     $front_url  = $front_id ? get_the_post_thumbnail_url( $front_id, 'full' ) : '';
     $back_url   = $back_id ? get_the_post_thumbnail_url( $back_id, 'full' ) : '';
 

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -29,14 +29,10 @@
 
     <div class="ws-preview">
       <img src="<?php echo esc_url( $default_front ?? '' ); ?>" alt="Mockup" class="ws-preview-img" />
-      <div id="design-zone" class="ws-design-zone">
-        <button class="ws-remove" title="Supprimer">×</button>
-        <div class="ws-handle ws-handle-nw"></div>
-        <div class="ws-handle ws-handle-ne"></div>
-        <div class="ws-handle ws-handle-sw"></div>
-        <div class="ws-handle ws-handle-se"></div>
-      </div>
+      <div id="ws-canvas" class="ws-canvas"></div>
     </div>
+
+    <input type="hidden" id="winshirt-custom-data" value="" />
 
     <div class="ws-actions">
       <div class="ws-toggle">


### PR DESCRIPTION
## Notes
- Execution de `php -l` impossible car l'interpréteur PHP n'est pas disponible.

## Summary
- masque du bouton de personnalisation si le produit n'est pas déclaré personnalisable ou sans mockup
- modernisation du template du modal et ajout d'un canvas pour placer plusieurs éléments
- refonte du script JS pour gérer l'ouverture/fermeture du modal, l'ajout et la manipulation d'éléments glissables
- mise à jour du style CSS pour le nouveau canvas et les items

## Testing
- `php -l includes/init.php` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68512fd572e48329bab9d499c46a29bc