### PR TITLE
Add dynamic personalizer features

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -2,7 +2,8 @@
 .ws-modal{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.6);backdrop-filter:blur(6px);z-index:9999}
 .hidden{display:none}
 .ws-modal.hidden{display:none}
-.ws-modal-content{position:relative;width:100%;max-width:960px;background:rgba(255,255,255,0.1);backdrop-filter:blur(16px) saturate(180%);border:1px solid rgba(255,255,255,0.2);border-radius:1rem;box-shadow:0 10px 25px rgba(0,0,0,0.3);padding:1.5rem;color:#fff;overflow:hidden}
+.ws-modal-content{position:relative;width:100%;max-width:960px;background:rgba(255,255,255,0.1);backdrop-filter:blur(16px) saturate(180%);border:1px solid rgba(255,255,255,0.2);border-radius:1rem;box-shadow:0 10px 25px rgba(0,0,0,0.3);padding:1.5rem;color:#fff;overflow:hidden;transform:scale(.9);opacity:0;transition:transform .3s,opacity .3s}
+.ws-modal.open .ws-modal-content{transform:scale(1);opacity:1}
 @media(max-width:640px){.ws-modal-content{height:100%;max-width:none;border-radius:0}}
 .ws-close{background:rgba(255,255,255,0.1);padding:.25rem .75rem;border:1px solid rgba(255,255,255,0.2);border-radius:.375rem;cursor:pointer;transition:background .2s}
 .ws-close:hover{background:rgba(255,255,255,0.2)}
@@ -30,3 +31,14 @@
 .ws-side-btn.active,.ws-side-btn:hover{background:rgba(255,255,255,0.2)}
 .ws-validate{background:#22c55e;padding:.5rem 1.5rem;border-radius:.5rem;color:#fff;cursor:pointer}
 .ws-validate:hover{background:#16a34a}
+.ws-colors{display:flex;gap:.25rem;margin-top:.5rem;flex-wrap:wrap;justify-content:center}
+.ws-color-btn{width:24px;height:24px;border-radius:50%;border:1px solid #fff;cursor:pointer;opacity:.8}
+.ws-color-btn.active{outline:2px solid #fff;opacity:1}
+.ws-print-zone{position:absolute;border:1px dashed rgba(255,255,255,0.7);pointer-events:none;display:none}
+.ws-item.ws-selected{outline:2px solid #93c5fd}
+.ws-formatting{display:flex;gap:.25rem;margin:.5rem 0}
+.ws-formatting button{background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.2);padding:.25rem .5rem;border-radius:.25rem;color:#fff;cursor:pointer}
+.ws-formatting button.active,.ws-formatting button:hover{background:rgba(255,255,255,0.3)}
+.ws-item.bold .ws-text{font-weight:700}
+.ws-item.italic .ws-text{font-style:italic}
+.ws-item.underline .ws-text{text-decoration:underline}

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -5,12 +5,41 @@ jQuery(function($){
   var state = {side:'front'};
   var $canvas = $('#ws-canvas');
   var $previewImg = $modal.find('.ws-preview-img');
+  var colors = $modal.data('colors') || [];
+  var zones  = $modal.data('zones') || [];
+  var $colorsWrap = $modal.find('.ws-colors');
+  var activeItem = null;
+
+  colors.forEach(function(c,idx){
+    var $b = $('<button class="ws-color-btn" />').css('background-color', c.code || '#fff').attr('data-index', idx);
+    $colorsWrap.append($b);
+  });
+
+  $colorsWrap.on('click', '.ws-color-btn', function(){
+    var col = colors[$(this).data('index')];
+    if(!col) return;
+    $colorsWrap.find('.ws-color-btn').removeClass('active');
+    $(this).addClass('active');
+    if(col.front){ $modal.data('default-front', col.front); if(state.side==='front') $previewImg.attr('src', col.front); }
+    if(col.back){ $modal.data('default-back', col.back); if(state.side==='back') $previewImg.attr('src', col.back); }
+  });
+
+  zones.forEach(function(z){
+    var $z = $modal.find('.ws-print-zone[data-side="'+z.side+'"]');
+    $z.css({top:z.top+'%',left:z.left+'%',width:z.width+'%',height:z.height+'%'});
+  });
+
+  function getContainment(){
+    var $zone = $modal.find('.ws-print-zone[data-side="'+state.side+'"]');
+    return $zone.length ? $zone : '.ws-preview';
+  }
 
   function openModal(){
-    $modal.removeClass('hidden');
+    $modal.removeClass('hidden').addClass('open');
   }
   function closeModal(){
-    $modal.addClass('hidden');
+    $modal.removeClass('open');
+    setTimeout(function(){ $modal.addClass('hidden'); }, 300);
   }
 
   $('#winshirt-open-modal').on('click', function(e){
@@ -39,15 +68,14 @@ jQuery(function($){
     $(this).val('');
   });
 
-  $('#winshirt-text-input').on('keydown', function(e){
-    if(e.key === 'Enter'){
-      e.preventDefault();
-      var txt = $(this).val().trim();
-      if(txt){
-        addItem('text', txt);
-        $(this).val('');
-      }
-    }
+  $('#ws-add-text').on('click', function(e){
+    e.preventDefault();
+    var txt = $('#ws-text-content').val().trim();
+    if(!txt) return;
+    var $it = addItem('text', txt);
+    $('#ws-text-content').val('');
+    applyTextStyles($it);
+    selectItem($it);
   });
 
   function addItem(type, content){
@@ -59,13 +87,48 @@ jQuery(function($){
     }
     $item.append('<button class="ws-remove" title="Supprimer">×</button>');
     $canvas.append($item);
-    $item.draggable({containment:'.ws-preview',snap:'.ws-preview',snapTolerance:10});
-    $item.resizable({handles:'n, e, s, w, ne, se, sw, nw',containment:'.ws-preview',snap:'.ws-preview',snapTolerance:10});
+    var cont = getContainment();
+    $item.draggable({containment:cont,snap:cont,snapTolerance:10});
+    $item.resizable({handles:'n, e, s, w, ne, se, sw, nw',containment:cont,snap:cont,snapTolerance:10});
+    return $item;
   }
 
   $(document).on('click', '.ws-remove', function(e){
     e.preventDefault();
     $(this).closest('.ws-item').remove();
+  });
+
+  $(document).on('mousedown', '.ws-item', function(e){
+    if($(e.target).is('.ws-remove')) return;
+    selectItem($(this));
+  });
+
+  function selectItem($it){
+    $('.ws-item').removeClass('ws-selected');
+    activeItem = $it;
+    if($it) $it.addClass('ws-selected');
+  }
+
+  function applyTextStyles($it){
+    if(!$it) return;
+    $it.find('.ws-text').css({
+      'font-family': $('#ws-font-select').val(),
+      'color': $('#ws-color-picker').val()
+    });
+    $it.toggleClass('bold', $('#ws-bold-btn').hasClass('active'));
+    $it.toggleClass('italic', $('#ws-italic-btn').hasClass('active'));
+    $it.toggleClass('underline', $('#ws-underline-btn').hasClass('active'));
+    var sc = parseFloat($('#ws-scale-range').val());
+    var rot = parseInt($('#ws-rotate-range').val(),10);
+    $it.css('transform','scale('+sc+') rotate('+rot+'deg)');
+  }
+
+  $('#ws-font-select,#ws-color-picker,#ws-scale-range,#ws-rotate-range,#ws-text-content').on('input change', function(){
+    applyTextStyles(activeItem);
+  });
+  $('#ws-bold-btn,#ws-italic-btn,#ws-underline-btn').on('click', function(){
+    $(this).toggleClass('active');
+    applyTextStyles(activeItem);
   });
 
   function switchSide(side){
@@ -75,11 +138,13 @@ jQuery(function($){
       $('#winshirt-front-btn').removeClass('active');
       $previewImg.attr('src', $modal.data('default-back'));
       $canvas.children('.ws-item').hide().filter('[data-side="back"]').show();
+      $modal.find('.ws-print-zone').hide().filter('[data-side="back"]').show();
     }else{
       $('#winshirt-front-btn').addClass('active');
       $('#winshirt-back-btn').removeClass('active');
       $previewImg.attr('src', $modal.data('default-front'));
       $canvas.children('.ws-item').hide().filter('[data-side="front"]').show();
+      $modal.find('.ws-print-zone').hide().filter('[data-side="front"]').show();
     }
   }
 

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -1,4 +1,4 @@
-<div id="winshirt-customizer-modal" class="ws-modal hidden" data-default-front="<?php echo esc_attr( $default_front ?? '' ); ?>" data-default-back="<?php echo esc_attr( $default_back ?? '' ); ?>">
+<div id="winshirt-customizer-modal" class="ws-modal hidden" data-default-front="<?php echo esc_attr( $default_front ?? '' ); ?>" data-default-back="<?php echo esc_attr( $default_back ?? '' ); ?>" data-colors='<?php echo esc_attr( $ws_colors ?? '[]' ); ?>' data-zones='<?php echo esc_attr( $ws_zones ?? '[]' ); ?>'>
   <div class="ws-modal-content">
     <div class="ws-tabs-header">
       <button class="ws-tab-button active" data-tab="gallery">🖼 Galerie</button>
@@ -16,7 +16,22 @@
     </div>
 
     <div class="ws-tab-content hidden" id="ws-tab-text">
-      <textarea id="winshirt-text-input" placeholder="Ajoutez votre texte ici..." class="ws-textarea"></textarea>
+      <input type="text" id="ws-text-content" class="ws-input" placeholder="Votre texte..." />
+      <select id="ws-font-select" class="ws-select">
+        <option value="Arial">Arial</option>
+        <option value="Georgia">Georgia</option>
+        <option value="Courier New">Courier New</option>
+        <option value="Times New Roman">Times</option>
+      </select>
+      <div class="ws-formatting">
+        <button type="button" id="ws-bold-btn">B</button>
+        <button type="button" id="ws-italic-btn">I</button>
+        <button type="button" id="ws-underline-btn">U</button>
+        <input type="color" id="ws-color-picker" value="#000000" />
+      </div>
+      <label><?php esc_html_e('Taille', 'winshirt'); ?> <input type="range" id="ws-scale-range" min="0.5" max="2" step="0.1" value="1"></label>
+      <label><?php esc_html_e('Rotation', 'winshirt'); ?> <input type="range" id="ws-rotate-range" min="0" max="360" step="1" value="0"></label>
+      <button class="ws-upload-btn" id="ws-add-text">Ajouter</button>
     </div>
 
     <div class="ws-tab-content hidden" id="ws-tab-ai">
@@ -30,7 +45,10 @@
     <div class="ws-preview">
       <img src="<?php echo esc_url( $default_front ?? '' ); ?>" alt="Mockup" class="ws-preview-img" />
       <div id="ws-canvas" class="ws-canvas"></div>
+      <div class="ws-print-zone" data-side="front"></div>
+      <div class="ws-print-zone" data-side="back"></div>
     </div>
+    <div class="ws-colors"></div>
 
     <input type="hidden" id="winshirt-custom-data" value="" />
 


### PR DESCRIPTION
## Summary
- conditionally show personalizer only when product is marked as customizable
- pass available colors and print zones to modal
- enhance modal markup for color swatches and text tools
- add glassmorphism animation and new styling
- implement JS for color choice, zone limits, text editing and item selection

## Testing
- `php -l includes/init.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685133644758832990526d921b4ceba9