### PR TITLE
Fix customizer modal desktop view

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -18,6 +18,8 @@
 .ws-upload-btn{margin-top:1rem;padding:.5rem 1rem;background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.2);border-radius:.5rem;color:#fff;cursor:pointer}
 .ws-upload-btn:hover{background:rgba(255,255,255,0.2)}
 .ws-gallery{display:flex;flex-wrap:wrap;gap:.5rem}
+.ws-gallery-thumb{width:64px;height:64px;object-fit:cover;border:1px solid rgba(255,255,255,0.2);border-radius:.25rem;cursor:pointer;transition:transform .2s}
+.ws-gallery-thumb:hover{transform:scale(1.05)}
 .ws-preview{position:relative;margin-top:1.5rem;width:100%;aspect-ratio:4/5;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.2);border-radius:.5rem;overflow:hidden;display:flex;align-items:center;justify-content:center}
 .ws-preview-img{max-width:100%;max-height:100%;object-fit:contain}
 .ws-canvas{position:absolute;inset:0}

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -1,6 +1,7 @@
 jQuery(function($){
   var $modal = $('#winshirt-customizer-modal');
   if(!$modal.length) return;
+  $('body').append($modal);
 
   var state = {side:'front'};
   var $canvas = $('#ws-canvas');
@@ -9,6 +10,16 @@ jQuery(function($){
   var zones  = $modal.data('zones') || [];
   var $colorsWrap = $modal.find('.ws-colors');
   var activeItem = null;
+
+  var gallery = $modal.data('gallery') || [];
+  var $gallery = $modal.find('.ws-gallery');
+  gallery.forEach(function(g){
+    var $img = $('<img class="ws-gallery-thumb" />').attr('src', g.url).attr('data-id', g.id).attr('alt', g.title || '');
+    $gallery.append($img);
+  });
+  $gallery.on('click', '.ws-gallery-thumb', function(){
+    addItem('image', $(this).attr('src'));
+  });
 
   colors.forEach(function(c,idx){
     var $b = $('<button class="ws-color-btn" />').css('background-color', c.code || '#fff').attr('data-index', idx);

--- a/includes/init.php
+++ b/includes/init.php
@@ -110,6 +110,34 @@ function winshirt_render_customize_button() {
     $default_back  = $back_url;
     $ws_colors     = wp_json_encode( $colors );
     $ws_zones      = wp_json_encode( $zones );
+
+    // Retrieve validated visuals for the gallery
+    $gallery_posts = get_posts([
+        'post_type'   => 'winshirt_visual',
+        'numberposts' => -1,
+        'orderby'     => 'date',
+        'order'       => 'DESC',
+        'meta_query'  => [
+            [
+                'key'   => '_winshirt_visual_validated',
+                'value' => 'yes',
+            ],
+        ],
+    ]);
+
+    $gallery = [];
+    foreach ( $gallery_posts as $g ) {
+        $url = get_the_post_thumbnail_url( $g->ID, 'full' );
+        if ( $url ) {
+            $gallery[] = [
+                'id'    => $g->ID,
+                'title' => $g->post_title,
+                'url'   => $url,
+                'type'  => get_post_meta( $g->ID, '_winshirt_visual_type', true ),
+            ];
+        }
+    }
+    $ws_gallery = wp_json_encode( $gallery );
     include WINSHIRT_PATH . 'templates/personalizer-modal.php';
 }
 add_action( 'woocommerce_single_product_summary', 'winshirt_render_customize_button', 35 );

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -1,4 +1,4 @@
-<div id="winshirt-customizer-modal" class="ws-modal hidden" data-default-front="<?php echo esc_attr( $default_front ?? '' ); ?>" data-default-back="<?php echo esc_attr( $default_back ?? '' ); ?>" data-colors='<?php echo esc_attr( $ws_colors ?? '[]' ); ?>' data-zones='<?php echo esc_attr( $ws_zones ?? '[]' ); ?>'>
+<div id="winshirt-customizer-modal" class="ws-modal hidden" data-default-front="<?php echo esc_attr( $default_front ?? '' ); ?>" data-default-back="<?php echo esc_attr( $default_back ?? '' ); ?>" data-colors='<?php echo esc_attr( $ws_colors ?? '[]' ); ?>' data-zones='<?php echo esc_attr( $ws_zones ?? '[]' ); ?>' data-gallery='<?php echo esc_attr( $ws_gallery ?? '[]' ); ?>'>
   <div class="ws-modal-content">
     <div class="ws-tabs-header">
       <button class="ws-tab-button active" data-tab="gallery">🖼 Galerie</button>


### PR DESCRIPTION
## Summary
- add gallery data to modal and display validated visuals
- style gallery thumbnails
- move modal element to body for proper overlay
- load gallery images with JS

## Testing
- `php -l includes/init.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685136c68a108329b383827571530c0d