### PR TITLE
Improve personalization modal

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -2,11 +2,13 @@
 .ws-modal{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.6);backdrop-filter:blur(6px);z-index:9999}
 .hidden{display:none}
 .ws-modal.hidden{display:none}
-.ws-modal-content{position:relative;display:flex;flex-direction:column;align-items:center;justify-content:center;width:100%;height:100%;max-width:none;background:rgba(255,255,255,0.1);backdrop-filter:blur(16px) saturate(180%);border:1px solid rgba(255,255,255,0.2);border-radius:0;box-shadow:0 10px 25px rgba(0,0,0,0.3);padding:1.5rem;color:#fff;overflow-y:auto;transform:scale(.9);opacity:0;transition:transform .3s,opacity .3s}
+.ws-modal-content{position:relative;display:flex;flex-direction:column;align-items:center;justify-content:center;width:100%;height:100%;max-width:none;background:rgba(255,255,255,0.05);backdrop-filter:blur(12px);border:1px solid rgba(255,255,255,0.2);border-radius:1rem;box-shadow:0 0 40px rgba(0,0,0,0.3);padding:1.5rem;color:#fff;overflow-y:auto;transform:scale(.9);opacity:0;transition:transform .3s,opacity .3s}
 .ws-modal.open .ws-modal-content{transform:scale(1);opacity:1}
 .ws-body{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;min-height:0}
 .ws-close{background:rgba(255,255,255,0.1);padding:.25rem .75rem;border:1px solid rgba(255,255,255,0.2);border-radius:.375rem;cursor:pointer;transition:background .2s}
 .ws-close:hover{background:rgba(255,255,255,0.2)}
+.ws-reset{background:rgba(255,255,255,0.1);padding:.25rem .75rem;border:1px solid rgba(255,255,255,0.2);border-radius:.375rem;cursor:pointer;transition:background .2s}
+.ws-reset:hover{background:rgba(255,255,255,0.2)}
 .ws-tabs-header{display:flex;gap:.5rem;margin-bottom:1rem;border-bottom:1px solid rgba(255,255,255,0.1);padding-bottom:.5rem;position:sticky;top:0;z-index:10;background:rgba(255,255,255,0.1);backdrop-filter:blur(16px) saturate(180%)}
 .ws-tab-button{padding:.5rem 1rem;border-radius:.5rem;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.2);cursor:pointer;transition:background .3s}
 .ws-ml-auto{margin-left:auto}
@@ -17,13 +19,22 @@
 .ws-textarea{width:100%;min-height:100px;border-radius:.5rem;padding:.75rem;color:#000;resize:none}
 .ws-upload-btn{margin-top:1rem;padding:.5rem 1rem;background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.2);border-radius:.5rem;color:#fff;cursor:pointer}
 .ws-upload-btn:hover{background:rgba(255,255,255,0.2)}
+.ws-gallery-cats{display:flex;gap:.5rem;margin-bottom:.5rem;flex-wrap:wrap}
+.ws-cat-btn{padding:.25rem .75rem;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.2);border-radius:.375rem;color:#fff;cursor:pointer;transition:background .2s}
+.ws-cat-btn.active,.ws-cat-btn:hover{background:rgba(255,255,255,0.2)}
 .ws-gallery{display:flex;flex-wrap:wrap;gap:.5rem}
 .ws-gallery-thumb{width:64px;height:64px;object-fit:cover;border:1px solid rgba(255,255,255,0.2);border-radius:.25rem;cursor:pointer;transition:transform .2s}
 .ws-gallery-thumb:hover{transform:scale(1.05)}
 .ws-preview{position:relative;margin-top:1.5rem;width:100%;aspect-ratio:4/5;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.2);border-radius:.5rem;overflow:hidden;display:flex;align-items:center;justify-content:center}
 .ws-preview-img{max-width:100%;max-height:100%;object-fit:contain}
 .ws-canvas{position:absolute;inset:0}
-.ws-item{position:absolute;border:2px dashed #60a5fa;background:rgba(255,255,255,0.2);border-radius:.25rem;cursor:move}
+.ws-item{position:absolute;border:2px dashed #60a5fa;background:rgba(255,255,255,0.2);border-radius:.25rem;cursor:move;transition:transform .2s ease}
+.ws-item .ui-resizable-handle{width:8px;height:8px;border-radius:50%;background:rgba(255,255,255,0.4);border:1px solid rgba(255,255,255,0.8);position:absolute;display:none}
+.ws-item .ui-resizable-nw{cursor:nwse-resize}
+.ws-item .ui-resizable-ne{cursor:nesw-resize}
+.ws-item .ui-resizable-sw{cursor:nesw-resize}
+.ws-item .ui-resizable-se{cursor:nwse-resize}
+.ws-item:hover .ui-resizable-handle,.ws-item.ws-selected .ui-resizable-handle{display:block}
 .ws-item img{width:100%;height:100%;object-fit:contain;display:block}
 .ws-item .ws-text{display:block;width:100%;height:100%;color:#000;text-align:center;word-break:break-word}
 .ws-remove{position:absolute;top:-12px;right:-12px;width:24px;height:24px;border-radius:50%;background:#ef4444;color:#fff;font-weight:bold;border:none;cursor:pointer}
@@ -37,7 +48,7 @@
 .ws-color-btn{width:24px;height:24px;border-radius:50%;border:1px solid #fff;cursor:pointer;opacity:.8}
 .ws-color-btn.active{outline:2px solid #fff;opacity:1}
 .ws-print-zone{position:absolute;border:1px dashed rgba(255,255,255,0.7);pointer-events:none;display:none}
-.ws-item.ws-selected{outline:2px solid #93c5fd}
+.ws-item.ws-selected{outline:1px solid #fff}
 .ws-formatting{display:flex;gap:.25rem;margin:.5rem 0}
 .ws-formatting button{background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.2);padding:.25rem .5rem;border-radius:.25rem;color:#fff;cursor:pointer}
 .ws-formatting button.active,.ws-formatting button:hover{background:rgba(255,255,255,0.3)}

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -5,6 +5,7 @@
       <button class="ws-tab-button" data-tab="text">🔤 Texte</button>
       <button class="ws-tab-button" data-tab="ai">🤖 IA</button>
       <button class="ws-tab-button" data-tab="svg">✒️ SVG</button>
+      <button id="ws-reset-visual" class="ws-reset">Réinitialiser ↺</button>
       <button id="winshirt-close-modal" class="ws-close ws-ml-auto">Fermer ✖️</button>
     </div>
 
@@ -12,6 +13,7 @@
 
     <div class="ws-tab-content" id="ws-tab-gallery">
       <p>Choisissez un design dans la galerie.</p>
+      <div class="ws-gallery-cats"></div>
       <div class="ws-gallery"></div>
       <button class="ws-upload-btn">Uploader un visuel</button>
       <input type="file" id="ws-upload-input" accept="image/*" class="hidden" />


### PR DESCRIPTION
## Summary
- add reset button and gallery categories
- style modal with stronger glassmorphism
- show fine handles for resizing visuals
- limit visual to single image and allow reset
- enable smooth drag and resize with transforms

## Testing
- `php -l templates/personalizer-modal.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68513f064224832987f1504c9b0822d0