### PR TITLE
Enable interactive print zone creation

### DIFF
--- a/assets/css/winshirt-mockups.css
+++ b/assets/css/winshirt-mockups.css
@@ -3,5 +3,7 @@
 #print-zone-wrapper{margin-top:15px;display:flex;gap:20px;flex-wrap:wrap;}
 #print-zone-wrapper .mockup-canvas{position:relative;display:inline-block;border:1px solid #ccc;}
 #print-zone-wrapper .print-zone{border:2px dashed #f00;position:absolute;background:rgba(255,0,0,0.2);text-align:center;color:#000;cursor:move;}
+#print-zone-wrapper .mockup-canvas.drawing{cursor:crosshair;}
+#print-zone-wrapper .print-zone.drawing{pointer-events:none;}
 #zone-controls .zone-row{margin-bottom:10px;border:1px solid #ddd;padding:10px;position:relative;}
 #zone-controls .remove-zone{position:absolute;top:4px;right:4px;}


### PR DESCRIPTION
## Summary
- allow drawing of print zones on mockups
- update coordinates while dragging/resizing
- add drawing cursor styles for clarity

## Testing
- `php -l includes/pages/mockups.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6851553ab7848329b91901cc38026e48