### PR TITLE
Implement fixed A3-A7 sizes in customizer

### DIFF
--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -18,7 +18,13 @@ jQuery(function($){
   var $colorsWrap = $modal.find('.ws-colors');
   var $formatWrap = $modal.find('.ws-format-buttons');
   var $formatBtns = $formatWrap.find('.ws-format-btn');
-  var formatRatios = {A3:0.8, A4:0.65, A5:0.5, A6:0.35, A7:0.2};
+  var formatSizes = {
+    A3: {w:700, h:990},
+    A4: {w:495, h:700},
+    A5: {w:350, h:495},
+    A6: {w:247, h:350},
+    A7: {w:175, h:247}
+  };
   var formatOrder = ['A3','A4','A5','A6','A7'];
   var activeItem = null;
 
@@ -85,14 +91,13 @@ jQuery(function($){
   }
 
   function detectFormat($it){
-    var $zone = $(getContainment());
-    var ref = Math.min($zone.width(), $zone.height());
-    var size = Math.max($it.width(), $it.height());
-    var ratio = size / ref;
+    var w = $it.width();
+    var h = $it.height();
     var fmt = formatOrder[formatOrder.length-1];
     for(var i=0;i<formatOrder.length;i++){
       var f = formatOrder[i];
-      if(ratio >= formatRatios[f]){ fmt = f; break; }
+      var s = formatSizes[f];
+      if(w >= s.w && h >= s.h){ fmt = f; break; }
     }
     return fmt;
   }
@@ -107,10 +112,10 @@ jQuery(function($){
     var zpos = $zone.position();
     var zw = $zone.width();
     var zh = $zone.height();
-    var size = Math.min(zw, zh) * (formatRatios[fmt] || 0);
-    var left = zpos.left + (zw - size)/2;
-    var top  = zpos.top + (zh - size)/2;
-    $it.css({width:size, height:size, left:left, top:top});
+    var s = formatSizes[fmt] || {w:0,h:0};
+    var left = zpos.left + (zw - s.w)/2;
+    var top  = zpos.top + (zh - s.h)/2;
+    $it.css({width:s.w, height:s.h, left:left, top:top});
     updateFormatButtons(fmt);
   }
 

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -63,13 +63,6 @@
         <div class="ws-print-zone" data-side="front"></div>
         <div class="ws-print-zone" data-side="back"></div>
       </div>
-      <div class="ws-format-buttons">
-        <button class="ws-format-btn" data-format="A3">A3</button>
-        <button class="ws-format-btn" data-format="A4">A4</button>
-        <button class="ws-format-btn" data-format="A5">A5</button>
-        <button class="ws-format-btn" data-format="A6">A6</button>
-        <button class="ws-format-btn" data-format="A7">A7</button>
-      </div>
 
       <div class="ws-sidebar hidden">
         <h3><?php esc_html_e( 'Édition', 'winshirt' ); ?></h3>
@@ -91,13 +84,20 @@
       <div class="ws-colors"></div>
       <input type="hidden" id="winshirt-custom-data" value="" />
 
-      <div class="ws-actions">
-        <div class="ws-toggle">
-          <button id="winshirt-front-btn" class="ws-side-btn active">Recto</button>
-          <button id="winshirt-back-btn" class="ws-side-btn">Verso</button>
+        <div class="ws-actions">
+          <div class="ws-toggle">
+            <button id="winshirt-front-btn" class="ws-side-btn active">Recto</button>
+            <button id="winshirt-back-btn" class="ws-side-btn">Verso</button>
+          </div>
+          <div class="ws-format-buttons">
+            <button class="ws-format-btn" data-format="A3">A3</button>
+            <button class="ws-format-btn" data-format="A4">A4</button>
+            <button class="ws-format-btn" data-format="A5">A5</button>
+            <button class="ws-format-btn" data-format="A6">A6</button>
+            <button class="ws-format-btn" data-format="A7">A7</button>
+          </div>
+          <button id="winshirt-validate" class="ws-validate">Valider la personnalisation</button>
         </div>
-        <button id="winshirt-validate" class="ws-validate">Valider la personnalisation</button>
-      </div>
 
     </div>
   </div>


### PR DESCRIPTION
## Summary
- align format selection with real A3–A7 proportions
- move format buttons to action bar

## Testing
- `php -l templates/personalizer-modal.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68515a3964dc8329a3f141e5ca7c04fb