### PR TITLE
Improve customization modal UI

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -16,8 +16,8 @@
 .ws-modal-content {
   position: relative;
   display: flex;
-  flex-direction: column;
-  align-items: center;
+  flex-direction: row;
+  align-items: flex-start;
   justify-content: center;
   width: 100%;
   height: 100%;
@@ -37,6 +37,20 @@
 .ws-modal.open .ws-modal-content {
   transform: scale(1);
   opacity: 1;
+}
+
+.ws-left {
+  flex-basis: 60%;
+  padding-right: 1rem;
+  box-sizing: border-box;
+}
+
+.ws-right {
+  flex-basis: 40%;
+  display: flex;
+  flex-direction: column;
+  max-height: 100%;
+  overflow-y: auto;
 }
 .ws-body {
   flex: 1;
@@ -348,12 +362,8 @@
 .ws-item.italic .ws-text { font-style: italic; }
 .ws-item.underline .ws-text { text-decoration: underline; }
 .ws-sidebar {
-  position: absolute;
-  top: 1.5rem;
-  right: 1.5rem;
-  width: 200px;
+  margin-top: 1rem;
   background: rgba(255,255,255,0.1);
-  backdrop-filter: blur(16px);
   border: 1px solid rgba(255,255,255,0.2);
   border-radius: .5rem;
   padding: 1rem;
@@ -364,9 +374,6 @@
 .ws-sidebar.show {
   display: flex;
 }
-@media(max-width:768px) {
-  .ws-sidebar { display: none!important; }
-}
 .ws-tabs-header::-webkit-scrollbar {
   display: none;
 }
@@ -376,6 +383,15 @@
     white-space: nowrap;
     -webkit-overflow-scrolling: touch;
   }
+}
+
+.ws-tab-select { display: none; margin-bottom: .5rem; }
+
+@media(max-width:768px){
+  .ws-modal-content { flex-direction: column; }
+  .ws-left, .ws-right { flex-basis: 100%; padding-right: 0; }
+  .ws-tab-select { display: block; }
+  .ws-tabs-header { display: none; }
 }
 .ws-sidebar label {
   display: flex;
@@ -392,6 +408,13 @@
 }
 .ws-delete:hover {
   background: #dc2626;
+}
+.ws-size-note {
+  display: block;
+  margin-top: .25rem;
+  font-size: .75rem;
+  opacity: .7;
+  text-align: center;
 }
 .ui-resizable-handle {
   position: absolute;

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -6,17 +6,32 @@
   data-gallery='<?php echo esc_attr( $ws_gallery ?? '[]' ); ?>'>
   
   <div class="ws-modal-content">
-    
-    <div class="ws-tabs-header">
-      <button class="ws-tab-button active" data-tab="gallery">🖼 Galerie</button>
-      <button class="ws-tab-button" data-tab="text">🔤 Texte</button>
-      <button class="ws-tab-button" data-tab="ai">🤖 IA</button>
-      <button class="ws-tab-button" data-tab="svg">✒️ SVG</button>
-      <button id="ws-reset-visual" class="ws-reset">Réinitialiser ↺</button>
-      <button id="winshirt-close-modal" class="ws-close ws-ml-auto">Fermer ✖️</button>
+
+    <div class="ws-left">
+      <div class="ws-preview">
+        <img src="<?php echo esc_url( $default_front ?? '' ); ?>" alt="Mockup" class="ws-preview-img" />
+        <div id="ws-canvas" class="ws-canvas"></div>
+        <div id="ws-print-zones"></div>
+      </div>
     </div>
 
-    <div class="ws-body">
+    <div class="ws-right">
+      <div class="ws-tabs-header">
+        <button class="ws-tab-button active" data-tab="gallery">🖼 Galerie</button>
+        <button class="ws-tab-button" data-tab="text">🔤 Texte</button>
+        <button class="ws-tab-button" data-tab="ai">🤖 IA</button>
+        <button class="ws-tab-button" data-tab="svg">✒️ SVG</button>
+        <button id="ws-reset-visual" class="ws-reset">Réinitialiser ↺</button>
+        <button id="winshirt-close-modal" class="ws-close ws-ml-auto">Fermer ✖️</button>
+      </div>
+
+      <select id="ws-tab-select" class="ws-tab-select">
+        <option value="gallery">Galerie</option>
+        <option value="text">Texte</option>
+        <option value="ai">IA</option>
+        <option value="svg">SVG</option>
+      </select>
+
 
       <div class="ws-tab-content" id="ws-tab-gallery">
         <p>Choisissez un design dans la galerie.</p>
@@ -57,11 +72,6 @@
         <p>Bibliothèque d’icônes vectorielles (SVG).</p>
       </div>
 
-      <div class="ws-preview">
-        <img src="<?php echo esc_url( $default_front ?? '' ); ?>" alt="Mockup" class="ws-preview-img" />
-        <div id="ws-canvas" class="ws-canvas"></div>
-        <div id="ws-print-zones"></div>
-      </div>
 
       <div class="ws-sidebar hidden">
         <h3><?php esc_html_e( 'Édition', 'winshirt' ); ?></h3>
@@ -96,6 +106,7 @@
             <button class="ws-format-btn" data-format="A7">A7</button>
             <span id="ws-current-format" class="ws-format-label"></span>
           </div>
+          <small class="ws-size-note">Taille réelle estimée basée sur un visuel 1500px.</small>
           <button id="winshirt-validate" class="ws-validate">Valider la personnalisation</button>
         </div>
 


### PR DESCRIPTION
## Summary
- restructure personalization modal layout with left preview and right sidebar
- support mobile navigation with dropdown tabs
- update format sizing logic for accurate A3-A7 ratios and dynamic label
- adjust styles for responsive design and new sidebar

## Testing
- `php -l templates/personalizer-modal.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851685ec6188329971bf57705f533af