### PR TITLE
Fix duplicate print zones

### DIFF
--- a/assets/js/winshirt-mockups.js
+++ b/assets/js/winshirt-mockups.js
@@ -34,6 +34,9 @@ jQuery(function($){
     }
 
     function createZone(index){
+        if($('.print-zone[data-index='+index+']').length){
+            return;
+        }
         var $row = $('.zone-row[data-index='+index+']');
         var side = $row.find('.zone-side').val();
         var fmt = $row.find('.zone-format').val();

--- a/templates/admin/partials/mockups-list.php
+++ b/templates/admin/partials/mockups-list.php
@@ -154,11 +154,15 @@
     <div id="print-zone-wrapper">
         <div id="mockup-canvas-front" class="mockup-canvas">
             <?php if ($front) { echo wp_get_attachment_image($front, 'medium'); } ?>
-            <?php foreach ($zones as $i => $z) { if ($z['side'] !== 'front') continue; echo '<div class="print-zone" data-index="'.$i.'" data-side="front" data-format="'.$z['format'].'" style="top:'.$z['top'].'%;left:'.$z['left'].'%;width:'.$z['width'].'%;height:'.$z['height'].'%;">'.$z['format'].'</div>'; } ?>
+            <?php foreach ($zones as $i => $z) : if ($z['side'] !== 'front') continue; ?>
+                <div class="print-zone" data-index="<?php echo esc_attr($i); ?>" data-side="front" data-format="<?php echo esc_attr($z['format']); ?>" style="top:<?php echo esc_attr($z['top']); ?>%;left:<?php echo esc_attr($z['left']); ?>%;width:<?php echo esc_attr($z['width']); ?>%;height:<?php echo esc_attr($z['height']); ?>%;"><?php echo esc_html($z['format']); ?></div>
+            <?php endforeach; ?>
         </div>
         <div id="mockup-canvas-back" class="mockup-canvas">
             <?php if ($back) { echo wp_get_attachment_image($back, 'medium'); } ?>
-            <?php foreach ($zones as $i => $z) { if ($z['side'] !== 'back') continue; echo '<div class="print-zone" data-index="'.$i.'" data-side="back" data-format="'.$z['format'].'" style="top:'.$z['top'].'%;left:'.$z['left'].'%;width:'.$z['width'].'%;height:'.$z['height'].'%;">'.$z['format'].'</div>'; } ?>
+            <?php foreach ($zones as $i => $z) : if ($z['side'] !== 'back') continue; ?>
+                <div class="print-zone" data-index="<?php echo esc_attr($i); ?>" data-side="back" data-format="<?php echo esc_attr($z['format']); ?>" style="top:<?php echo esc_attr($z['top']); ?>%;left:<?php echo esc_attr($z['left']); ?>%;width:<?php echo esc_attr($z['width']); ?>%;height:<?php echo esc_attr($z['height']); ?>%;"><?php echo esc_html($z['format']); ?></div>
+            <?php endforeach; ?>
         </div>
     </div>
     <p>


### PR DESCRIPTION
## Summary
- avoid creating duplicate print zone elements when the template already rendered them
- only output existing print zone markup once in the mockups admin form

## Testing
- `php -l templates/admin/partials/mockups-list.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685176eb37ec8329a9c71572b3794df5