### PR TITLE
Persist customizer data between sessions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -15,7 +15,7 @@ Une page "Produits" est disponible dans le menu WinShirt pour associer des mocku
 L'onglet "Visuels" permet d'importer ou supprimer des images. Les visuels peuvent être filtrés par type ou date et validés avant utilisation.
 
 ## Personnalisation de produits
-Un bouton "Personnaliser ce produit" ouvre un modale sur la fiche produit pour choisir un design, saisir du texte ou importer une image. Les sélections sont temporairement sauvegardées via localStorage.
+Un bouton "Personnaliser ce produit" ouvre un modale sur la fiche produit pour choisir un design, saisir du texte ou importer une image. Les sélections sont temporairement sauvegardées via localStorage et sont automatiquement restaurées lors de la réouverture du modale.
 
 ## Gestion des loteries
 Une page "Loteries" permet de créer et d'administrer les tirages. Chaque loterie peut être liée à un produit WooCommerce, disposer de dates de début/fin, de lots à gagner et d'une animation personnalisée. Les participants enregistrés et leur nombre sont visibles depuis cette interface.


### PR DESCRIPTION
## Summary
- keep customization state in `localStorage`
- restore saved state when opening the modal
- document this new behaviour in the readme

## Testing
- `node - <<'EOF'
const fs=require('fs');
try{ new Function(fs.readFileSync('assets/js/winshirt-modal.js','utf8')); console.log('syntax ok'); }
catch(e){ console.error('error',e.message); process.exit(1); }
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685176ee2130832983dda7bd2dff4859