### PR TITLE
Add animated lottery cards on product pages

### DIFF
--- a/assets/css/winshirt-lottery.css
+++ b/assets/css/winshirt-lottery.css
@@ -1,5 +1,35 @@
-.winshirt-lottery-info{border:1px solid #ccc;padding:10px;margin-bottom:15px;text-align:center}
-.winshirt-lottery-info img{max-width:100px;display:block;margin:0 auto 10px}
-.winshirt-lottery-progress{background:#eee;border-radius:4px;overflow:hidden;height:8px;margin-top:5px}
-.winshirt-lottery-progress .bar{height:8px;width:0;background:green}
-.winshirt-lottery-full{color:#c00;font-weight:bold;margin-top:5px}
+.lottery-card {
+  background: linear-gradient(145deg, #1a1a1a, #232323);
+  border-radius: 1rem;
+  padding: 1rem;
+  color: #fff;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.4);
+  transform-style: preserve-3d;
+  transition: transform 0.3s ease;
+  perspective: 1000px;
+}
+.lottery-card:hover {
+  transform: scale(1.02) rotateX(3deg) rotateY(-3deg);
+}
+.lottery-card img {
+  width: 100%;
+  border-radius: 0.75rem;
+  margin-bottom: 1rem;
+}
+.lottery-progress {
+  height: 6px;
+  background: #444;
+  border-radius: 3px;
+  overflow: hidden;
+  margin-top: 0.5rem;
+}
+.lottery-progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, #7f5af0, #5eead4);
+  transition: width 0.5s ease;
+}
+.lottery-full {
+  color: #c00;
+  font-weight: bold;
+  margin-top: 5px;
+}

--- a/assets/js/winshirt-lottery.js
+++ b/assets/js/winshirt-lottery.js
@@ -13,21 +13,21 @@ jQuery(function($){
     if(typeof data === 'string'){
       try{ data = JSON.parse(data); } catch(e){ data = {}; }
     }
-    var html = '<div class="winshirt-lottery-info">';
-    if(data.img) html += '<img src="'+data.img+'" alt="" />';
-    html += '<h3>'+$opt.text()+'</h3>';
-    if(data.tickets) html += '<p>+'+data.tickets+' tickets</p>';
-    if(data.max){
-      var percent = data.max > 0 ? Math.min(100, (data.count/data.max)*100) : 0;
-      html += '<p>'+data.count+' / '+data.max+' participants</p>';
-      html += '<div class="winshirt-lottery-progress"><div class="bar" style="width:'+percent+'%;background:'+(percent>80?'#c00':(percent>50?'#e67e00':'#2ecc71'))+'"></div></div>';
-      if(data.count >= data.max) html += '<p class="winshirt-lottery-full">Loterie complète</p>';
-    }else if(typeof data.count !== 'undefined'){
-      html += '<p>'+data.count+' participants</p>';
-    }
-    html += '</div>';
+
+    var percent = data.goal ? Math.min(100, (data.participants / data.goal) * 100) : 0;
+    var draw = data.drawDate ? '<p style="margin-top:1rem;">\ud83d\udcc5 Tirage le '+data.drawDate+'</p>' : '';
+    var img = data.image ? '<img src="'+data.image+'" alt="'+(data.name||$opt.text())+'" />' : '';
+
+    var html = '<div class="lottery-card">'+
+      img+
+      '<h3>'+(data.name||$opt.text())+'</h3>'+
+      '<p>\ud83c\udf39 +'+data.tickets+' tickets</p>'+
+      '<p>'+data.participants+' / '+data.goal+' participants</p>'+
+      '<div class="lottery-progress"><div class="lottery-progress-bar" style="width:'+percent+'%"></div></div>'+
+      draw+
+      '</div>';
     $info.html(html);
   }
 
-  $select.on('change', update);
+  $select.on('change', update).trigger('change');
 });

--- a/includes/init.php
+++ b/includes/init.php
@@ -170,15 +170,18 @@ function winshirt_render_lottery_selector() {
     echo '<select id="winshirt-lottery-select">';
     echo '<option value="">' . esc_html__( '-- Sélectionner --', 'winshirt' ) . '</option>';
     foreach ( $lotteries as $lottery ) {
-        $max    = absint( get_post_meta( $lottery->ID, 'max_participants', true ) );
-        $count  = absint( get_post_meta( $lottery->ID, 'participants_count', true ) );
-        $img_id = get_post_meta( $lottery->ID, '_winshirt_lottery_animation', true );
-        $img_url= $img_id ? wp_get_attachment_image_url( $img_id, 'thumbnail' ) : '';
-        $info   = wp_json_encode([
-            'tickets' => $tickets,
-            'max'     => $max,
-            'count'   => $count,
-            'img'     => $img_url,
+        $max       = absint( get_post_meta( $lottery->ID, 'max_participants', true ) );
+        $count     = absint( get_post_meta( $lottery->ID, 'participants_count', true ) );
+        $img_id    = get_post_meta( $lottery->ID, '_winshirt_lottery_animation', true );
+        $img_url   = $img_id ? wp_get_attachment_image_url( $img_id, 'thumbnail' ) : '';
+        $draw_date = get_post_meta( $lottery->ID, '_winshirt_lottery_end', true );
+        $info      = wp_json_encode([
+            'tickets'      => $tickets,
+            'goal'         => $max,
+            'participants' => $count,
+            'image'        => $img_url,
+            'name'         => $lottery->post_title,
+            'drawDate'     => $draw_date,
         ]);
         echo '<option value="' . esc_attr( $lottery->ID ) . '" data-info="' . esc_attr( $info ) . '">' . esc_html( $lottery->post_title ) . '</option>';
     }
@@ -205,24 +208,21 @@ function winshirt_render_lottery_info() {
     $count     = absint( get_post_meta( $lottery, 'participants_count', true ) );
     $img_id    = get_post_meta( $lottery, '_winshirt_lottery_animation', true );
     $img_url   = $img_id ? wp_get_attachment_image_url( $img_id, 'thumbnail' ) : '';
+    $draw_date = get_post_meta( $lottery, '_winshirt_lottery_end', true );
     $percent   = $max > 0 ? min( 100, ( $count / $max ) * 100 ) : 0;
 
-    echo '<div class="winshirt-lottery-info">';
-    echo '<h3>' . esc_html( get_the_title( $lottery ) ) . '</h3>';
+    echo '<div class="lottery-card">';
     if ( $img_url ) {
         echo '<img src="' . esc_url( $img_url ) . '" alt="" />';
     }
+    echo '<h3>' . esc_html( get_the_title( $lottery ) ) . '</h3>';
     if ( $tickets ) {
-        echo '<p>+' . esc_html( $tickets ) . ' tickets</p>';
+        echo '<p>🎟️ +' . esc_html( $tickets ) . ' tickets</p>';
     }
-    if ( $max ) {
-        echo '<p>' . esc_html( $count . ' / ' . $max . ' participants' ) . '</p>';
-        echo '<div class="winshirt-lottery-progress"><div class="bar" style="width:' . esc_attr( $percent ) . '%;background:' . ( $percent > 80 ? '#c00' : ( $percent > 50 ? '#e67e00' : '#2ecc71' ) ) . '"></div></div>';
-        if ( $count >= $max ) {
-            echo '<p class="winshirt-lottery-full">' . esc_html__( 'Loterie complète', 'winshirt' ) . '</p>';
-        }
-    } else {
-        echo '<p>' . esc_html( $count ) . ' participants</p>';
+    echo '<p>' . esc_html( $count . ' / ' . $max . ' participants' ) . '</p>';
+    echo '<div class="lottery-progress"><div class="lottery-progress-bar" style="width:' . esc_attr( $percent ) . '%"></div></div>';
+    if ( $draw_date ) {
+        echo '<p style="margin-top:1rem;">📅 ' . esc_html__( 'Tirage le', 'winshirt' ) . ' ' . esc_html( $draw_date ) . '</p>';
     }
     echo '</div>';
 }


### PR DESCRIPTION
## Summary
- overhaul front-end lottery styling with animated card design
- render richer lottery data in the selector options
- update PHP output for default lottery to use the new card layout

## Testing
- `php -l` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68525cbe91ac8329ab6fc213d1a50054