### PR TITLE
Implement uninstall cleanup

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -1,1 +1,50 @@
-<?php // cleanup if needed later
+<?php
+/**
+ * Uninstallation cleanup for the WinShirt plugin.
+ */
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit;
+}
+
+// Delete plugin options
+delete_option( 'winshirt_ftp_host' );
+delete_option( 'winshirt_ftp_user' );
+delete_option( 'winshirt_ftp_pass' );
+
+// Remove custom posts created by the plugin
+$post_types = [ 'winshirt_mockup', 'winshirt_visual', 'winshirt_lottery' ];
+foreach ( $post_types as $type ) {
+    $posts = get_posts([
+        'post_type'   => $type,
+        'numberposts' => -1,
+        'post_status' => 'any',
+    ]);
+    foreach ( $posts as $p ) {
+        wp_delete_post( $p->ID, true );
+    }
+}
+
+// Clean product meta that references WinShirt data
+$meta_keys = [
+    '_winshirt_mockups',
+    '_winshirt_visuals',
+    '_winshirt_default_mockup_front',
+    '_winshirt_default_mockup_back',
+    '_winshirt_show_button',
+    '_winshirt_enabled',
+    'linked_lottery',
+    'loterie_tickets',
+];
+
+$products = get_posts([
+    'post_type'   => 'product',
+    'numberposts' => -1,
+    'post_status' => 'any',
+]);
+
+foreach ( $products as $product ) {
+    foreach ( $meta_keys as $key ) {
+        delete_post_meta( $product->ID, $key );
+    }
+}

--- a/winshirt.php
+++ b/winshirt.php
@@ -19,6 +19,19 @@ require_once WINSHIRT_PATH . 'includes/pages/loteries.php';
 require_once WINSHIRT_PATH . 'includes/pages/commandes.php';
 require_once WINSHIRT_PATH . 'includes/pages/configuration.php';
 
+// Register uninstall hook
+register_uninstall_hook(__FILE__, 'winshirt_plugin_uninstall');
+
+/**
+ * Callback executed on plugin uninstall.
+ *
+ * Loads the dedicated uninstall script which cleans up
+ * options and custom post data created by the plugin.
+ */
+function winshirt_plugin_uninstall() {
+    require_once WINSHIRT_PATH . 'uninstall.php';
+}
+
 // Register WinShirt admin pages
 add_action('admin_menu', 'winshirt_register_admin_pages');
 


### PR DESCRIPTION
## Summary
- hook `register_uninstall_hook` in the main plugin file
- add uninstall script to remove plugin data and posts

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852636699788329b6408f885bfaed53