### PR TITLE
Add lottery shortcode and fix visual placement

### DIFF
--- a/assets/css/winshirt-lottery.css
+++ b/assets/css/winshirt-lottery.css
@@ -33,3 +33,14 @@
   font-weight: bold;
   margin-top: 5px;
 }
+.ws-lottery-card{position:relative;background:linear-gradient(145deg,#1a1a1a,#232323);border-radius:1rem;padding:1rem;color:#fff;box-shadow:0 10px 30px rgba(0,0,0,0.4);transition:transform .3s ease;overflow:hidden}
+.ws-lottery-card img{width:100%;border-radius:.75rem;margin-bottom:1rem}
+.ws-lottery-card .lottery-badge{position:absolute;top:.5rem;left:.5rem;background:#22c55e;padding:.25rem .5rem;border-radius:.25rem;font-size:.75rem;font-weight:700}
+.ws-lottery-card .badge-featured{left:auto;right:.5rem;background:#a855f7}
+.ws-lottery-card .lottery-title{font-size:1.25rem;margin:0 0 .25rem}
+.ws-lottery-card .lottery-value{font-size:.875rem;margin:0 0 .25rem}
+.ws-lottery-card .lottery-timer{font-size:.875rem;margin-bottom:.5rem}
+.ws-lottery-card .lottery-count{font-size:.875rem;margin:0.25rem 0}
+.ws-lottery-card .lottery-draw{font-size:.75rem;margin-top:.5rem;opacity:.8}
+.ws-lottery-card .lottery-button{display:inline-block;margin-top:.75rem;padding:.5rem 1rem;border-radius:.5rem;background:#2563eb;color:#fff;text-decoration:none}
+.ws-lottery-card .lottery-button:hover{background:#1d4ed8}

--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -336,6 +336,8 @@
 #ws-print-zones {
   position: absolute;
   inset: 0;
+  width: 100%;
+  height: 100%;
   pointer-events: none;
 }
 .ws-format-label {

--- a/assets/js/winshirt-lottery-box.js
+++ b/assets/js/winshirt-lottery-box.js
@@ -1,0 +1,35 @@
+jQuery(function($){
+  $('.ws-lottery-card').each(function(){
+    var $card = $(this);
+    var end = $card.data('end');
+    if(end){
+      function update(){
+        var diff = new Date(end) - new Date();
+        if(diff <= 0){
+          $card.find('.lottery-timer').text('Terminé');
+          clearInterval(int);
+          return;
+        }
+        var d = Math.floor(diff / 86400000);
+        var h = Math.floor((diff % 86400000) / 3600000);
+        var m = Math.floor((diff % 3600000) / 60000);
+        var s = Math.floor((diff % 60000) / 1000);
+        $card.find('.lottery-timer').text(d+'j '+h+'h '+m+'m '+s+'s');
+      }
+      update();
+      var int = setInterval(update,1000);
+    }
+
+    $card.on('mousemove', function(e){
+      var w = $card.outerWidth();
+      var h = $card.outerHeight();
+      var x = e.offsetX - w/2;
+      var y = e.offsetY - h/2;
+      var rx = (y/h)*6;
+      var ry = -(x/w)*6;
+      $card.css('transform','rotateX('+rx+'deg) rotateY('+ry+'deg) scale(1.03)');
+    }).on('mouseleave', function(){
+      $card.css('transform','');
+    });
+  });
+});

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -371,7 +371,12 @@ function openModal(){
       var cont = getContainment();
       var cw = $(cont).width();
       var ch = $(cont).height();
+      if(!cw || !ch){
+        cw = $canvas.width();
+        ch = $canvas.height();
+      }
       var size = Math.min(cw, ch) * 0.5;
+      if(!size){ size = 100; }
       $item.css({width:size,height:size});
     } else {
       $item.append('<span class="ws-text">'+content+'</span>');

--- a/includes/init.php
+++ b/includes/init.php
@@ -12,6 +12,72 @@ add_action('wp_enqueue_scripts', function () {
     }
 });
 
+// Enqueue assets when the lottery shortcode is present
+add_action('wp_enqueue_scripts', function(){
+    global $post;
+    if ( isset( $post->post_content ) && has_shortcode( $post->post_content, 'loterie_box' ) ) {
+        wp_enqueue_style('winshirt-lottery', WINSHIRT_URL . 'assets/css/winshirt-lottery.css', [], '1.0');
+        wp_enqueue_script('winshirt-lottery-box', WINSHIRT_URL . 'assets/js/winshirt-lottery-box.js', ['jquery'], '1.0', true);
+    }
+});
+
+/**
+ * Display a lottery card anywhere with [loterie_box id="123" vedette="true"].
+ */
+function winshirt_lottery_box_shortcode( $atts ) {
+    $atts = shortcode_atts([
+        'id'      => 0,
+        'vedette' => 'false',
+    ], $atts, 'loterie_box');
+
+    $id = absint( $atts['id'] );
+    if ( ! $id ) {
+        return '';
+    }
+
+    $lottery = get_post( $id );
+    if ( ! $lottery || $lottery->post_type !== 'winshirt_lottery' ) {
+        return '';
+    }
+
+    $active      = get_post_meta( $id, '_winshirt_lottery_active', true ) === 'yes';
+    $value       = get_post_meta( $id, '_winshirt_lottery_value', true );
+    $max         = absint( get_post_meta( $id, 'max_participants', true ) );
+    $count       = absint( get_post_meta( $id, 'participants_count', true ) );
+    $draw_date   = get_post_meta( $id, '_winshirt_lottery_end', true );
+    $img_id      = get_post_meta( $id, '_winshirt_lottery_animation', true );
+    $img_url     = $img_id ? wp_get_attachment_image_url( $img_id, 'large' ) : '';
+    $percent     = $max > 0 ? min( 100, ( $count / $max ) * 100 ) : 0;
+
+    ob_start();
+    ?>
+    <div class="ws-lottery-card" data-end="<?php echo esc_attr( $draw_date ); ?>">
+        <?php if ( $active ) : ?>
+            <span class="lottery-badge">Active</span>
+        <?php endif; ?>
+        <?php if ( $atts['vedette'] === 'true' ) : ?>
+            <span class="lottery-badge badge-featured">En vedette</span>
+        <?php endif; ?>
+        <?php if ( $img_url ) : ?>
+            <img src="<?php echo esc_url( $img_url ); ?>" alt="" />
+        <?php endif; ?>
+        <h3 class="lottery-title"><?php echo esc_html( $lottery->post_title ); ?></h3>
+        <?php if ( $value ) : ?>
+            <p class="lottery-value">Valeur : <?php echo esc_html( $value ); ?>€</p>
+        <?php endif; ?>
+        <div class="lottery-timer"></div>
+        <p class="lottery-count"><?php echo esc_html( $count . ' participants - Objectif : ' . $max ); ?></p>
+        <div class="lottery-progress"><div class="lottery-progress-bar" style="width:<?php echo esc_attr( $percent ); ?>%"></div></div>
+        <?php if ( $draw_date ) : ?>
+            <p class="lottery-draw"><?php echo esc_html( $draw_date ); ?></p>
+        <?php endif; ?>
+        <a href="#" class="lottery-button">Participer</a>
+    </div>
+    <?php
+    return ob_get_clean();
+}
+add_shortcode( 'loterie_box', 'winshirt_lottery_box_shortcode' );
+
 // Register custom post type for lotteries
 add_action('init', function () {
     register_post_type('winshirt_lottery', [


### PR DESCRIPTION
## Summary
- avoid zero-sized images when adding gallery visuals
- ensure print zone container fills preview
- add responsive lottery card styles and script
- enqueue new assets when `[loterie_box]` shortcode is used
- implement `loterie_box` shortcode

## Testing
- `php -l includes/init.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685267e9553c83298173791318aa3450