### PR TITLE
Add lottery shortcode display

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -78,6 +78,35 @@ function winshirt_lottery_box_shortcode( $atts ) {
 }
 add_shortcode( 'loterie_box', 'winshirt_lottery_box_shortcode' );
 
+/**
+ * Display only the lottery thumbnail image.
+ * Usage: [loterie_thumb id="123" size="thumbnail"].
+ */
+function winshirt_lottery_thumb_shortcode( $atts ) {
+    $atts = shortcode_atts([
+        'id'   => 0,
+        'size' => 'thumbnail',
+    ], $atts, 'loterie_thumb');
+
+    $id = absint( $atts['id'] );
+    if ( ! $id ) {
+        return '';
+    }
+
+    $img_id = get_post_meta( $id, '_winshirt_lottery_animation', true );
+    if ( ! $img_id ) {
+        return '';
+    }
+
+    $size = sanitize_key( $atts['size'] );
+    if ( ! $size ) {
+        $size = 'thumbnail';
+    }
+
+    return wp_get_attachment_image( $img_id, $size );
+}
+add_shortcode( 'loterie_thumb', 'winshirt_lottery_thumb_shortcode' );
+
 // Register custom post type for lotteries
 add_action('init', function () {
     register_post_type('winshirt_lottery', [

--- a/templates/admin/partials/loteries-list.php
+++ b/templates/admin/partials/loteries-list.php
@@ -12,6 +12,7 @@
             <th><?php esc_html_e('Dates', 'winshirt'); ?></th>
             <th style="text-align:center;">Actif</th>
             <th><?php esc_html_e('Participations', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Shortcode', 'winshirt'); ?></th>
             <th><?php esc_html_e('Actions', 'winshirt'); ?></th>
         </tr>
     </thead>
@@ -33,13 +34,16 @@
                 <td style="text-align:center;"><input type="checkbox" disabled <?php checked($active); ?> /></td>
                 <td><?php echo esc_html($count); ?></td>
                 <td>
+                    <input type="text" readonly class="regular-text code" value="[loterie_thumb id=&quot;<?php echo esc_attr($lottery->ID); ?>&quot;]" onclick="this.select();" />
+                </td>
+                <td>
                     <a class="button" href="<?php echo esc_url(add_query_arg(['page' => 'winshirt-lotteries', 'edit' => $lottery->ID], admin_url('admin.php'))); ?>"><?php esc_html_e('Modifier', 'winshirt'); ?></a>
                     <a class="button delete" href="<?php echo esc_url(wp_nonce_url(add_query_arg(['page' => 'winshirt-lotteries', 'delete' => $lottery->ID], admin_url('admin.php')), 'delete_lottery_' . $lottery->ID)); ?>"><?php esc_html_e('Supprimer', 'winshirt'); ?></a>
                 </td>
             </tr>
         <?php endforeach; ?>
     <?php else : ?>
-        <tr><td colspan="6"><?php esc_html_e('Aucune loterie', 'winshirt'); ?></td></tr>
+        <tr><td colspan="7"><?php esc_html_e('Aucune loterie', 'winshirt'); ?></td></tr>
     <?php endif; ?>
     </tbody>
 </table>


### PR DESCRIPTION
## Summary
- show shortcode in the admin lottery list
- add `[loterie_thumb]` shortcode to output the lottery image

## Testing
- `php -l includes/init.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852873f635c83299d86459f484dde45