### PR TITLE
Improve lottery card on product page

### DIFF
--- a/assets/css/winshirt-lottery.css
+++ b/assets/css/winshirt-lottery.css
@@ -82,3 +82,14 @@
 .ws-lottery-list .ws-lottery-card{
   flex:1 1 280px;
 }
+
+#winshirt-lottery-info{
+  margin-top:1rem;
+  display:flex;
+  justify-content:center;
+}
+
+#winshirt-lottery-info .ws-lottery-card{
+  max-width:400px;
+  width:100%;
+}

--- a/assets/js/winshirt-lottery.js
+++ b/assets/js/winshirt-lottery.js
@@ -3,7 +3,36 @@ jQuery(function($){
   if(!$select.length) return;
   var $info = $('#winshirt-lottery-info');
 
-  function update(){
+  function initCard($card, end){
+    $card.on('mousemove', function(e){
+      var rect = this.getBoundingClientRect();
+      var x = (e.clientX - rect.left - rect.width / 2) / 20;
+      var y = (e.clientY - rect.top - rect.height / 2) / 20;
+      this.style.transform = 'rotateX('+y+'deg) rotateY('+x+'deg) scale(1.05)';
+    }).on('mouseleave', function(){
+      this.style.transform = '';
+    });
+
+    if(end){
+      var $timer = $card.find('.lottery-timer');
+      function updateTimer(){
+        var diff = new Date(end) - new Date();
+        if(diff <= 0){
+          $timer.text('Terminé');
+          clearInterval(int);
+          return;
+        }
+        var d = Math.floor(diff/86400000);
+        var h = Math.floor((diff%86400000)/3600000);
+        var m = Math.floor((diff%3600000)/60000);
+        $timer.text(d+' JOURS - '+h+' HEURES - '+m+' MINUTES');
+      }
+      updateTimer();
+      var int = setInterval(updateTimer,60000);
+    }
+  }
+
+  function render(){
     var $opt = $select.find('option:selected');
     var data = $opt.data('info');
     if(!data){
@@ -11,23 +40,29 @@ jQuery(function($){
       return;
     }
     if(typeof data === 'string'){
-      try{ data = JSON.parse(data); } catch(e){ data = {}; }
+      try{ data = JSON.parse(data); }catch(e){ data = {}; }
     }
 
     var percent = data.goal ? Math.min(100, (data.participants / data.goal) * 100) : 0;
-    var draw = data.drawDate ? '<p style="margin-top:1rem;">\ud83d\udcc5 Tirage le '+data.drawDate+'</p>' : '';
-    var img = data.image ? '<img src="'+data.image+'" alt="'+(data.name||$opt.text())+'" />' : '';
-
-    var html = '<div class="lottery-card">'+
+    var img = data.image ? '<div class="lottery-image"><img src="'+data.image+'" alt="" /></div>' : '';
+    var badge = '<span class="lottery-badge">'+(data.active ? 'Active' : 'Terminée')+'</span>';
+    var badgeF = data.featured ? '<span class="lottery-badge badge-featured">En vedette</span>' : '';
+    var value = data.value ? '<p class="lottery-value">Valeur : '+data.value+' €</p>' : '';
+    var draw = data.drawDate ? '<p class="lottery-draw">Tirage le '+data.drawDate+'</p>' : '';
+    var html = '<div class="ws-lottery-card" data-end="'+(data.drawDate||'')+'">'+
+      badge+badgeF+
       img+
-      '<h3>'+(data.name||$opt.text())+'</h3>'+
-      '<p>\ud83c\udf39 +'+data.tickets+' tickets</p>'+
-      '<p>'+data.participants+' / '+data.goal+' participants</p>'+
+      '<h3 class="lottery-title">'+(data.name||$opt.text())+'</h3>'+
+      value+
+      '<div class="lottery-timer"></div>'+
       '<div class="lottery-progress"><div class="lottery-progress-bar" style="width:'+percent+'%"></div></div>'+
+      '<p class="lottery-count">'+data.participants+' participants / Objectif : '+data.goal+'</p>'+
       draw+
       '</div>';
     $info.html(html);
+    initCard($info.find('.ws-lottery-card'), data.drawDate);
   }
 
-  $select.on('change', update).trigger('change');
+  $select.on('change', render);
+  render();
 });

--- a/includes/init.php
+++ b/includes/init.php
@@ -327,8 +327,11 @@ function winshirt_render_lottery_selector() {
         $max       = absint( get_post_meta( $lottery->ID, 'max_participants', true ) );
         $count     = absint( get_post_meta( $lottery->ID, 'participants_count', true ) );
         $img_id    = get_post_meta( $lottery->ID, '_winshirt_lottery_animation', true );
-        $img_url   = $img_id ? wp_get_attachment_image_url( $img_id, 'thumbnail' ) : '';
+        $img_url   = $img_id ? wp_get_attachment_image_url( $img_id, 'large' ) : '';
         $draw_date = get_post_meta( $lottery->ID, '_winshirt_lottery_end', true );
+        $active    = get_post_meta( $lottery->ID, '_winshirt_lottery_active', true ) === 'yes';
+        $value     = get_post_meta( $lottery->ID, '_winshirt_lottery_value', true );
+        $featured  = get_post_meta( $lottery->ID, '_winshirt_lottery_featured', true ) === 'yes';
         $info      = wp_json_encode([
             'tickets'      => $tickets,
             'goal'         => $max,
@@ -336,6 +339,9 @@ function winshirt_render_lottery_selector() {
             'image'        => $img_url,
             'name'         => $lottery->post_title,
             'drawDate'     => $draw_date,
+            'active'       => $active,
+            'value'        => $value,
+            'featured'     => $featured,
         ]);
         echo '<option value="' . esc_attr( $lottery->ID ) . '" data-info="' . esc_attr( $info ) . '">' . esc_html( $lottery->post_title ) . '</option>';
     }


### PR DESCRIPTION
## Summary
- show a centered lottery card when a lottery is selected
- provide card details with featured and active badges
- style lottery info container
- add tilt & countdown JS for product page lottery

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68529892b41c8329bcde624746d998b7