### PR TITLE
Refactor lottery card JS

### DIFF
--- a/assets/js/winshirt-lottery-box.js
+++ b/assets/js/winshirt-lottery-box.js
@@ -1,35 +1,7 @@
 jQuery(function($){
   $('.ws-lottery-card').each(function(){
-    var $card = $(this);
-    var end = $card.data('end');
-    if(end){
-      function update(){
-        var diff = new Date(end) - new Date();
-        if(diff <= 0){
-          $card.find('.lottery-timer').text('Terminé');
-          clearInterval(int);
-          return;
-        }
-        var d = Math.floor(diff / 86400000);
-        var h = Math.floor((diff % 86400000) / 3600000);
-        var m = Math.floor((diff % 3600000) / 60000);
-        var s = Math.floor((diff % 60000) / 1000);
-        $card.find('.lottery-timer').text(d+'j '+h+'h '+m+'m '+s+'s');
-      }
-      update();
-      var int = setInterval(update,1000);
+    if(window.WinshirtLotteryCard){
+      window.WinshirtLotteryCard.initCard(this, {interval:1000});
     }
-
-    $card.on('mousemove', function(e){
-      var w = $card.outerWidth();
-      var h = $card.outerHeight();
-      var x = e.offsetX - w/2;
-      var y = e.offsetY - h/2;
-      var rx = (y/h)*6;
-      var ry = -(x/w)*6;
-      $card.css('transform','rotateX('+rx+'deg) rotateY('+ry+'deg) scale(1.03)');
-    }).on('mouseleave', function(){
-      $card.css('transform','');
-    });
   });
 });

--- a/assets/js/winshirt-lottery-card.js
+++ b/assets/js/winshirt-lottery-card.js
@@ -1,0 +1,61 @@
+(function(window){
+  'use strict';
+
+  function pad(n){return n<10?'0'+n:n;}
+
+  function initTilt(card){
+    var img = card.querySelector('[data-tilt] img, img');
+    if(window.VanillaTilt && img){
+      window.VanillaTilt.init(img, {max:8, speed:400, scale:1.05});
+    } else {
+      card.addEventListener('mousemove', function(e){
+        var rect = card.getBoundingClientRect();
+        var x = (e.clientX - rect.left - rect.width/2)/20;
+        var y = (e.clientY - rect.top - rect.height/2)/20;
+        card.style.transform = 'rotateX('+y+'deg) rotateY('+x+'deg) scale(1.05)';
+      });
+      card.addEventListener('mouseleave', function(){
+        card.style.transform = '';
+      });
+    }
+  }
+
+  function initCountdown(card, end, interval){
+    if(!end) return;
+    var timer = card.querySelector('.lottery-timer');
+    if(!timer) return;
+    var endDate = new Date(end);
+    interval = interval || 60000;
+    function update(){
+      var diff = endDate - new Date();
+      if(diff <= 0){
+        timer.textContent = 'Terminé';
+        clearInterval(id);
+        return;
+      }
+      var d = Math.floor(diff/86400000);
+      var h = Math.floor((diff%86400000)/3600000);
+      var m = Math.floor((diff%3600000)/60000);
+      if(interval === 1000){
+        var s = Math.floor((diff%60000)/1000);
+        timer.textContent = d+'j '+pad(h)+'h '+pad(m)+'m '+pad(s)+'s';
+      } else {
+        timer.textContent = d+' JOURS - '+h+' HEURES - '+m+' MINUTES';
+      }
+    }
+    update();
+    var id = setInterval(update, interval);
+  }
+
+  function initCard(card, opts){
+    opts = opts || {};
+    initTilt(card);
+    initCountdown(card, card.dataset.end, opts.interval);
+  }
+
+  window.WinshirtLotteryCard = {
+    initTilt: initTilt,
+    initCountdown: initCountdown,
+    initCard: initCard
+  };
+})(window);

--- a/assets/js/winshirt-lottery-cards.js
+++ b/assets/js/winshirt-lottery-cards.js
@@ -1,27 +1,7 @@
 jQuery(function($){
   $('.ws-lottery-card').each(function(){
-    var $card = $(this);
-    var $img = $card.find('img');
-    if($img.length && window.VanillaTilt){
-      VanillaTilt.init($img[0], {max:8, speed:400, scale:1.05});
-    }
-    var end = $card.data('end');
-    if(end){
-      end = new Date(end);
-      function update(){
-        var diff = end - new Date();
-        if(diff <= 0){
-          $card.find('.lottery-timer').text('Terminé');
-          clearInterval(timer);
-          return;
-        }
-        var d = Math.floor(diff/86400000);
-        var h = Math.floor((diff%86400000)/3600000);
-        var m = Math.floor((diff%3600000)/60000);
-        $card.find('.lottery-timer').text(d+' JOURS - '+h+' HEURES - '+m+' MINUTES');
-      }
-      update();
-      var timer = setInterval(update,60000);
+    if(window.WinshirtLotteryCard){
+      window.WinshirtLotteryCard.initCard(this, {interval:60000});
     }
   });
 });

--- a/assets/js/winshirt-lottery.js
+++ b/assets/js/winshirt-lottery.js
@@ -3,35 +3,6 @@ jQuery(function($){
   if(!$select.length) return;
   var $info = $('#winshirt-lottery-info');
 
-  function initCard($card, end){
-    $card.on('mousemove', function(e){
-      var rect = this.getBoundingClientRect();
-      var x = (e.clientX - rect.left - rect.width / 2) / 20;
-      var y = (e.clientY - rect.top - rect.height / 2) / 20;
-      this.style.transform = 'rotateX('+y+'deg) rotateY('+x+'deg) scale(1.05)';
-    }).on('mouseleave', function(){
-      this.style.transform = '';
-    });
-
-    if(end){
-      var $timer = $card.find('.lottery-timer');
-      function updateTimer(){
-        var diff = new Date(end) - new Date();
-        if(diff <= 0){
-          $timer.text('Terminé');
-          clearInterval(int);
-          return;
-        }
-        var d = Math.floor(diff/86400000);
-        var h = Math.floor((diff%86400000)/3600000);
-        var m = Math.floor((diff%3600000)/60000);
-        $timer.text(d+' JOURS - '+h+' HEURES - '+m+' MINUTES');
-      }
-      updateTimer();
-      var int = setInterval(updateTimer,60000);
-    }
-  }
-
   function render(){
     var $opt = $select.find('option:selected');
     var data = $opt.data('info');
@@ -60,7 +31,9 @@ jQuery(function($){
       draw+
       '</div>';
     $info.html(html);
-    initCard($info.find('.ws-lottery-card'), data.drawDate);
+    if(window.WinshirtLotteryCard){
+      window.WinshirtLotteryCard.initCard($info.find('.ws-lottery-card')[0], {interval:60000});
+    }
   }
 
   $select.on('change', render);

--- a/includes/init.php
+++ b/includes/init.php
@@ -8,7 +8,9 @@ add_action('wp_enqueue_scripts', function () {
         wp_enqueue_style('winshirt-lottery', WINSHIRT_URL . 'assets/css/winshirt-lottery.css', [], '1.0');
         wp_enqueue_script('winshirt-touch', WINSHIRT_URL . 'assets/js/jquery.ui.touch-punch.min.js', ['jquery', 'jquery-ui-mouse'], '0.2.3', true);
         wp_enqueue_script('winshirt-modal', WINSHIRT_URL . 'assets/js/winshirt-modal.js', ['jquery', 'jquery-ui-draggable', 'jquery-ui-resizable', 'winshirt-touch'], '1.0', true);
-        wp_enqueue_script('winshirt-lottery-select', WINSHIRT_URL . 'assets/js/winshirt-lottery.js', ['jquery'], '1.0', true);
+        wp_enqueue_script('vanilla-tilt', WINSHIRT_URL . 'assets/js/vanilla-tilt.min.js', [], '1.0', true);
+        wp_enqueue_script('winshirt-lottery-card', WINSHIRT_URL . 'assets/js/winshirt-lottery-card.js', ['vanilla-tilt'], '1.0', true);
+        wp_enqueue_script('winshirt-lottery-select', WINSHIRT_URL . 'assets/js/winshirt-lottery.js', ['jquery', 'winshirt-lottery-card'], '1.0', true);
     }
 });
 
@@ -18,7 +20,8 @@ add_action('wp_enqueue_scripts', function(){
     if ( isset( $post->post_content ) && ( has_shortcode( $post->post_content, 'loterie_box' ) || has_shortcode( $post->post_content, 'winshirt_lotteries' ) ) ) {
         wp_enqueue_style( 'winshirt-lottery', WINSHIRT_URL . 'assets/css/winshirt-lottery.css', [], '1.0' );
         wp_enqueue_script( 'vanilla-tilt', WINSHIRT_URL . 'assets/js/vanilla-tilt.min.js', [], '1.0', true );
-        wp_enqueue_script( 'winshirt-lottery-cards', WINSHIRT_URL . 'assets/js/winshirt-lottery-cards.js', [ 'jquery', 'vanilla-tilt' ], '1.0', true );
+        wp_enqueue_script( 'winshirt-lottery-card', WINSHIRT_URL . 'assets/js/winshirt-lottery-card.js', [ 'vanilla-tilt' ], '1.0', true );
+        wp_enqueue_script( 'winshirt-lottery-cards', WINSHIRT_URL . 'assets/js/winshirt-lottery-cards.js', [ 'jquery', 'winshirt-lottery-card' ], '1.0', true );
     }
 });
 


### PR DESCRIPTION
## Summary
- add a reusable `winshirt-lottery-card.js` helper
- update lottery scripts to use the new helper
- enqueue `winshirt-lottery-card.js` where lottery cards are used

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b26011d08329a835b6935dbf81d5