### PR TITLE
Add animated lottery card effects

### DIFF
--- a/assets/css/winshirt-lottery.css
+++ b/assets/css/winshirt-lottery.css
@@ -55,7 +55,7 @@
 }
 .ws-lottery-card .lottery-progress-bar{
   height:100%;
-  width:0;
+  width:var(--progress,0);
   background:#2563eb;
   transition:width .3s ease;
 }
@@ -92,4 +92,39 @@
 #winshirt-lottery-info .ws-lottery-card{
   max-width:400px;
   width:100%;
+}
+/* Animations */
+@keyframes progress-fill {
+  from { width: 0; }
+  to { width: var(--progress, 100%); }
+}
+
+@keyframes card-shine {
+  from { transform: translateX(-100%) rotate(45deg); }
+  to { transform: translateX(200%) rotate(45deg); }
+}
+
+@keyframes fade-in-up {
+  from { opacity:0; transform: translateY(20px); }
+  to { opacity:1; transform: translateY(0); }
+}
+
+.ws-lottery-card.fade-in-up {
+  animation: fade-in-up .4s ease forwards;
+}
+
+.ws-lottery-card.card-shine::after {
+  content:'';
+  position:absolute;
+  top:0;
+  left:-100%;
+  width:50%;
+  height:100%;
+  pointer-events:none;
+  background:linear-gradient(120deg,rgba(255,255,255,0.2),rgba(255,255,255,0.8),rgba(255,255,255,0.2));
+  animation: card-shine 1.2s forwards;
+}
+
+.lottery-progress-bar.animate-progress {
+  animation: progress-fill 1s forwards;
 }

--- a/assets/js/winshirt-lottery-cards.js
+++ b/assets/js/winshirt-lottery-cards.js
@@ -1,27 +1,48 @@
-jQuery(function($){
-  $('.ws-lottery-card').each(function(){
-    var $card = $(this);
-    var $img = $card.find('img');
+(function($){
+  window.initWinshirtLotteryCard = function(card){
+    var $card = $(card);
+    var $img = $card.find('[data-tilt] img, img[data-tilt], .lottery-image[data-tilt] img');
     if($img.length && window.VanillaTilt){
       VanillaTilt.init($img[0], {max:8, speed:400, scale:1.05});
     }
+
+    $card.addClass('fade-in-up card-shine');
+
     var end = $card.data('end');
     if(end){
       end = new Date(end);
+      var $timer = $card.find('.lottery-timer');
       function update(){
         var diff = end - new Date();
         if(diff <= 0){
-          $card.find('.lottery-timer').text('Terminé');
+          $timer.text('Terminé');
           clearInterval(timer);
           return;
         }
         var d = Math.floor(diff/86400000);
         var h = Math.floor((diff%86400000)/3600000);
         var m = Math.floor((diff%3600000)/60000);
-        $card.find('.lottery-timer').text(d+' JOURS - '+h+' HEURES - '+m+' MINUTES');
+        $timer.text(d+' JOURS - '+h+' HEURES - '+m+' MINUTES');
       }
       update();
       var timer = setInterval(update,60000);
     }
+
+    var $progress = $card.find('.lottery-progress-bar');
+    if($progress.length){
+      var p = parseFloat($progress.data('progress'));
+      if(isNaN(p)){
+        var w = $progress.width();
+        var pw = $progress.parent().width();
+        p = pw ? w/pw*100 : 0;
+      }
+      $progress.css('--progress', p + '%').addClass('animate-progress');
+    }
+  };
+
+  $(function(){
+    $('.ws-lottery-card').each(function(){
+      window.initWinshirtLotteryCard(this);
+    });
   });
-});
+})(jQuery);

--- a/assets/js/winshirt-lottery.js
+++ b/assets/js/winshirt-lottery.js
@@ -3,35 +3,6 @@ jQuery(function($){
   if(!$select.length) return;
   var $info = $('#winshirt-lottery-info');
 
-  function initCard($card, end){
-    $card.on('mousemove', function(e){
-      var rect = this.getBoundingClientRect();
-      var x = (e.clientX - rect.left - rect.width / 2) / 20;
-      var y = (e.clientY - rect.top - rect.height / 2) / 20;
-      this.style.transform = 'rotateX('+y+'deg) rotateY('+x+'deg) scale(1.05)';
-    }).on('mouseleave', function(){
-      this.style.transform = '';
-    });
-
-    if(end){
-      var $timer = $card.find('.lottery-timer');
-      function updateTimer(){
-        var diff = new Date(end) - new Date();
-        if(diff <= 0){
-          $timer.text('Terminé');
-          clearInterval(int);
-          return;
-        }
-        var d = Math.floor(diff/86400000);
-        var h = Math.floor((diff%86400000)/3600000);
-        var m = Math.floor((diff%3600000)/60000);
-        $timer.text(d+' JOURS - '+h+' HEURES - '+m+' MINUTES');
-      }
-      updateTimer();
-      var int = setInterval(updateTimer,60000);
-    }
-  }
-
   function render(){
     var $opt = $select.find('option:selected');
     var data = $opt.data('info');
@@ -55,12 +26,14 @@ jQuery(function($){
       '<h3 class="lottery-title">'+(data.name||$opt.text())+'</h3>'+
       value+
       '<div class="lottery-timer"></div>'+
-      '<div class="lottery-progress"><div class="lottery-progress-bar" style="width:'+percent+'%"></div></div>'+
+      '<div class="lottery-progress"><div class="lottery-progress-bar" data-progress="'+percent+'" style="width:'+percent+'%"></div></div>'+
       '<p class="lottery-count">'+data.participants+' participants / Objectif : '+data.goal+'</p>'+
       draw+
       '</div>';
     $info.html(html);
-    initCard($info.find('.ws-lottery-card'), data.drawDate);
+    if(window.initWinshirtLotteryCard){
+      window.initWinshirtLotteryCard($info.find('.ws-lottery-card')[0]);
+    }
   }
 
   $select.on('change', render);

--- a/includes/init.php
+++ b/includes/init.php
@@ -8,7 +8,9 @@ add_action('wp_enqueue_scripts', function () {
         wp_enqueue_style('winshirt-lottery', WINSHIRT_URL . 'assets/css/winshirt-lottery.css', [], '1.0');
         wp_enqueue_script('winshirt-touch', WINSHIRT_URL . 'assets/js/jquery.ui.touch-punch.min.js', ['jquery', 'jquery-ui-mouse'], '0.2.3', true);
         wp_enqueue_script('winshirt-modal', WINSHIRT_URL . 'assets/js/winshirt-modal.js', ['jquery', 'jquery-ui-draggable', 'jquery-ui-resizable', 'winshirt-touch'], '1.0', true);
-        wp_enqueue_script('winshirt-lottery-select', WINSHIRT_URL . 'assets/js/winshirt-lottery.js', ['jquery'], '1.0', true);
+        wp_enqueue_script('vanilla-tilt', WINSHIRT_URL . 'assets/js/vanilla-tilt.min.js', [], '1.0', true);
+        wp_enqueue_script('winshirt-lottery-cards', WINSHIRT_URL . 'assets/js/winshirt-lottery-cards.js', ['jquery', 'vanilla-tilt'], '1.0', true);
+        wp_enqueue_script('winshirt-lottery-select', WINSHIRT_URL . 'assets/js/winshirt-lottery.js', ['jquery', 'winshirt-lottery-cards'], '1.0', true);
     }
 });
 
@@ -68,7 +70,7 @@ function winshirt_lottery_box_shortcode( $atts ) {
         <?php endif; ?>
         <div class="lottery-timer"></div>
         <p class="lottery-count"><?php echo esc_html( $count . ' participants - Objectif : ' . $max ); ?></p>
-        <div class="lottery-progress"><div class="lottery-progress-bar" style="width:<?php echo esc_attr( $percent ); ?>%"></div></div>
+        <div class="lottery-progress"><div class="lottery-progress-bar" data-progress="<?php echo esc_attr( $percent ); ?>" style="width:<?php echo esc_attr( $percent ); ?>%"></div></div>
         <?php if ( $draw_date ) : ?>
             <p class="lottery-draw"><?php echo esc_html( $draw_date ); ?></p>
         <?php endif; ?>
@@ -152,7 +154,7 @@ function winshirt_lotteries_shortcode() {
                 <p class="lottery-value">Valeur : <?php echo esc_html( $value ); ?> €</p>
             <?php endif; ?>
             <div class="lottery-timer"></div>
-            <div class="lottery-progress"><div class="lottery-progress-bar" style="width:<?php echo esc_attr( $percent ); ?>%"></div></div>
+            <div class="lottery-progress"><div class="lottery-progress-bar" data-progress="<?php echo esc_attr( $percent ); ?>" style="width:<?php echo esc_attr( $percent ); ?>%"></div></div>
             <p class="lottery-count"><?php echo esc_html( $count . ' participants / Objectif : ' . $max ); ?></p>
             <?php if ( $draw_date ) : ?>
                 <p class="lottery-draw">Tirage le <?php echo esc_html( date_i18n( 'd/m/Y', strtotime( $draw_date ) ) ); ?></p>
@@ -380,7 +382,7 @@ function winshirt_render_lottery_info() {
         echo '<p>🎟️ +' . esc_html( $tickets ) . ' tickets</p>';
     }
     echo '<p>' . esc_html( $count . ' / ' . $max . ' participants' ) . '</p>';
-    echo '<div class="lottery-progress"><div class="lottery-progress-bar" style="width:' . esc_attr( $percent ) . '%"></div></div>';
+    echo '<div class="lottery-progress"><div class="lottery-progress-bar" data-progress="' . esc_attr( $percent ) . '" style="width:' . esc_attr( $percent ) . '%"></div></div>';
     if ( $draw_date ) {
         echo '<p style="margin-top:1rem;">📅 ' . esc_html__( 'Tirage le', 'winshirt' ) . ' ' . esc_html( $draw_date ) . '</p>';
     }


### PR DESCRIPTION
## Summary
- animate lottery cards with fade-in, progress and shine effects
- add a reusable JS helper to initialize cards with VanillaTilt
- trigger animations when lottery details are loaded on product pages
- enqueue VanillaTilt and card script for product pages as well

## Testing
- `php -l includes/init.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b26141b0832988c7be0755fa6add