### PR TITLE
Add lottery shortcodes list and admin help

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -19,3 +19,8 @@ Un bouton "Personnaliser ce produit" ouvre un modale sur la fiche produit pour c
 
 ## Gestion des loteries
 Une page "Loteries" permet de créer et d'administrer les tirages. Chaque loterie peut être liée à un produit WooCommerce, disposer de dates de début/fin, de lots à gagner et d'une animation personnalisée. Les participants enregistrés et leur nombre sont visibles depuis cette interface.
+
+## Shortcodes
+* `[loterie_box id="123" vedette="true"]` – carte complète d'une loterie avec ses détails.
+* `[winshirt_lotteries]` – liste de toutes les loteries sous forme de cartes.
+* `[loterie_thumb id="123"]` – uniquement l'image miniature de la loterie.

--- a/templates/admin/partials/loteries-list.php
+++ b/templates/admin/partials/loteries-list.php
@@ -12,7 +12,7 @@
             <th><?php esc_html_e('Dates', 'winshirt'); ?></th>
             <th style="text-align:center;">Actif</th>
             <th><?php esc_html_e('Participations', 'winshirt'); ?></th>
-            <th><?php esc_html_e('Shortcode', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Shortcodes', 'winshirt'); ?></th>
             <th><?php esc_html_e('Actions', 'winshirt'); ?></th>
         </tr>
     </thead>
@@ -34,7 +34,10 @@
                 <td style="text-align:center;"><input type="checkbox" disabled <?php checked($active); ?> /></td>
                 <td><?php echo esc_html($count); ?></td>
                 <td>
+                    <input type="text" readonly class="regular-text code" value="[loterie_box id=&quot;<?php echo esc_attr($lottery->ID); ?>&quot;]" onclick="this.select();" />
+                    <p class="description"><?php esc_html_e('Carte complète', 'winshirt'); ?></p>
                     <input type="text" readonly class="regular-text code" value="[loterie_thumb id=&quot;<?php echo esc_attr($lottery->ID); ?>&quot;]" onclick="this.select();" />
+                    <p class="description"><?php esc_html_e('Miniature uniquement', 'winshirt'); ?></p>
                 </td>
                 <td>
                     <a class="button" href="<?php echo esc_url(add_query_arg(['page' => 'winshirt-lotteries', 'edit' => $lottery->ID], admin_url('admin.php'))); ?>"><?php esc_html_e('Modifier', 'winshirt'); ?></a>
@@ -47,6 +50,9 @@
     <?php endif; ?>
     </tbody>
 </table>
+<p class="description">
+    <?php esc_html_e('Utilisez [loterie_box id="123"] pour afficher la carte complète ou [loterie_thumb id="123"] pour uniquement la miniature (remplacez 123 par l\'ID de la loterie).', 'winshirt'); ?>
+</p>
 
 <?php if ($editing) : ?>
 <h2><?php esc_html_e('Participants', 'winshirt'); ?> (<?php echo count($participants); ?>)</h2>


### PR DESCRIPTION
## Summary
- show `[loterie_box]` and `[loterie_thumb]` in the lotteries admin table
- rename the table column to "Shortcodes"
- add a hint describing how to use the shortcodes
- document all lottery shortcodes in `readme.txt`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852b89cce0483299104e3f27eabe8cf