### PR TITLE
Add lottery shortcode info

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -19,3 +19,8 @@ Un bouton "Personnaliser ce produit" ouvre un modale sur la fiche produit pour c
 
 ## Gestion des loteries
 Une page "Loteries" permet de créer et d'administrer les tirages. Chaque loterie peut être liée à un produit WooCommerce, disposer de dates de début/fin, de lots à gagner et d'une animation personnalisée. Les participants enregistrés et leur nombre sont visibles depuis cette interface.
+
+## Shortcodes
+* `[loterie_box id="123" vedette="true"]` – carte individuelle de loterie avec tous les détails.
+* `[winshirt_lotteries]` – liste de toutes les loteries sous forme de cartes.
+* `[loterie_thumb id="123"]` – uniquement l'image miniature.

--- a/templates/admin/partials/loteries-list.php
+++ b/templates/admin/partials/loteries-list.php
@@ -2,8 +2,16 @@
 /**
  * Admin lottery management interface.
  * Variables: $lotteries, $editing, $participants
- */
+*/
 ?>
+<p class="description">
+    <?php
+    esc_html_e(
+        'Utilisez [loterie_box id="123"] pour afficher la carte complète, [loterie_thumb id="123"] pour la miniature et [winshirt_lotteries] pour la liste complète.',
+        'winshirt'
+    );
+    ?>
+</p>
 <table class="widefat fixed">
     <thead>
         <tr>
@@ -12,7 +20,7 @@
             <th><?php esc_html_e('Dates', 'winshirt'); ?></th>
             <th style="text-align:center;">Actif</th>
             <th><?php esc_html_e('Participations', 'winshirt'); ?></th>
-            <th><?php esc_html_e('Shortcode', 'winshirt'); ?></th>
+            <th><?php esc_html_e('Shortcodes', 'winshirt'); ?></th>
             <th><?php esc_html_e('Actions', 'winshirt'); ?></th>
         </tr>
     </thead>
@@ -34,7 +42,16 @@
                 <td style="text-align:center;"><input type="checkbox" disabled <?php checked($active); ?> /></td>
                 <td><?php echo esc_html($count); ?></td>
                 <td>
-                    <input type="text" readonly class="regular-text code" value="[loterie_thumb id=&quot;<?php echo esc_attr($lottery->ID); ?>&quot;]" onclick="this.select();" />
+                    <div style="margin-bottom:4px;">
+                        <input type="text" readonly class="regular-text code" value="[loterie_box id=&quot;<?php echo esc_attr($lottery->ID); ?>&quot;]" onclick="this.select();" />
+                        <br/>
+                        <small><?php esc_html_e('Carte complète', 'winshirt'); ?></small>
+                    </div>
+                    <div>
+                        <input type="text" readonly class="regular-text code" value="[loterie_thumb id=&quot;<?php echo esc_attr($lottery->ID); ?>&quot;]" onclick="this.select();" />
+                        <br/>
+                        <small><?php esc_html_e('Miniature', 'winshirt'); ?></small>
+                    </div>
                 </td>
                 <td>
                     <a class="button" href="<?php echo esc_url(add_query_arg(['page' => 'winshirt-lotteries', 'edit' => $lottery->ID], admin_url('admin.php'))); ?>"><?php esc_html_e('Modifier', 'winshirt'); ?></a>


### PR DESCRIPTION
## Summary
- show both `[loterie_box]` and `[loterie_thumb]` in the admin lottery list
- explain available shortcodes in the admin page
- document shortcodes in `readme.txt`

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852be2145ac8329b391dde520561bc1