### PR TITLE
Fix lottery card flash animation

### DIFF
--- a/assets/css/winshirt-lottery.css
+++ b/assets/css/winshirt-lottery.css
@@ -101,7 +101,7 @@
 
 @keyframes card-shine {
   from { transform: translateX(-100%) rotate(45deg); }
-  to { transform: translateX(200%) rotate(45deg); }
+  to { transform: translateX(400%) rotate(45deg); }
 }
 
 @keyframes fade-in-up {
@@ -122,7 +122,7 @@
   height:100%;
   pointer-events:none;
   background:linear-gradient(120deg,rgba(255,255,255,0.2),rgba(255,255,255,0.8),rgba(255,255,255,0.2));
-  animation: card-shine 1.2s forwards;
+  animation: card-shine 0.6s linear forwards;
 }
 
 .lottery-progress-bar.animate-progress {


### PR DESCRIPTION
## Summary
- adjust `card-shine` keyframes so the gradient sweeps across the card
- speed up the animation for a quick flash effect

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6852c2dc70c0832995f104ac1f23b7aa