### PR TITLE
Improve customizer UI

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -7,6 +7,7 @@
   justify-content: center;
   background: rgba(0,0,0,0.6);
   backdrop-filter: blur(6px);
+  padding: 1%;
   z-index: 9999;
 }
 .hidden,
@@ -43,6 +44,9 @@
   flex-basis: 75%;
   padding-right: 1rem;
   box-sizing: border-box;
+  position: sticky;
+  top: 0;
+  align-self: flex-start;
 }
 
 .ws-right {
@@ -210,7 +214,7 @@
   background: rgba(255,255,255,0.2);
   border-radius: .25rem;
   cursor: move;
-  transition: transform .2s ease;
+  transition: none;
 }
 .ws-item .ui-resizable-handle {
   width: 8px;


### PR DESCRIPTION
## Summary
- add small padding around customizer modal
- keep preview area fixed with sticky positioning
- remove transform transition from draggable items for smoother dragging

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852c7b0922c8329820fa509bc47d57a