### PR TITLE
Fix lottery counter update after payment

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -484,7 +484,8 @@ function winshirt_register_lottery_participant( $order_id ) {
         update_post_meta( $lottery, 'participants_count', $count + $increment );
     }
 }
-add_action( 'woocommerce_thankyou', 'winshirt_register_lottery_participant' );
+// Update lottery participation when a payment is confirmed
+add_action( 'woocommerce_payment_complete', 'winshirt_register_lottery_participant' );
 
 // Register custom post type for mockups
 add_action('init', function () {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: shakass
 Tags: woocommerce, personnalisation, t-shirt, loterie
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.0
+Stable tag: 1.0.1
 License: GPLv2 or later
 
 Plugin pour personnalisation de produits et loteries via WooCommerce.

--- a/winshirt.php
+++ b/winshirt.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WinShirt by Shakass
  * Description: Module de personnalisation produit et loteries pour WooCommerce.
- * Version: 1.0
+ * Version: 1.0.1
  * Author: Shakass Communication
  */
 


### PR DESCRIPTION
## Summary
- update lottery counter when payment completes
- bump plugin version to 1.0.1

## Testing
- `php -l includes/init.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68532a25458c8329913e7e708ce4bf85