### PR TITLE
Fix duplicate lottery selection and update participant counts

### DIFF
--- a/assets/js/winshirt-lottery-selected.js
+++ b/assets/js/winshirt-lottery-selected.js
@@ -11,16 +11,14 @@ jQuery(function($){
 
   function renderAll(){
     $container.empty();
-    var shown = {};
 
     $selects.each(function(index){
       var $select = $(this);
       var $opt    = $select.find('option:selected');
       var lid     = $opt.val();
-      if(!lid || shown[lid]){
+      if(!lid){
         return;
       }
-      shown[lid] = true;
 
       var data = $opt.data('info');
       if(typeof data === 'string'){

--- a/includes/init.php
+++ b/includes/init.php
@@ -459,6 +459,10 @@ function winshirt_register_lottery_participant( $order_id ) {
         return;
     }
 
+    if ( $order->get_meta( '_winshirt_lottery_participants_registered' ) === 'yes' ) {
+        return;
+    }
+
     foreach ( $order->get_items() as $item ) {
         $lotteries = $item->get_meta( '_winshirt_lotteries', true );
         if ( $lotteries ) {
@@ -483,9 +487,14 @@ function winshirt_register_lottery_participant( $order_id ) {
         }
         update_post_meta( $lottery, 'participants_count', $count + $increment );
     }
+
+    $order->update_meta_data( '_winshirt_lottery_participants_registered', 'yes' );
+    $order->save();
 }
 // Update lottery participation when a payment is confirmed
 add_action( 'woocommerce_payment_complete', 'winshirt_register_lottery_participant' );
+add_action( 'woocommerce_order_status_processing', 'winshirt_register_lottery_participant' );
+add_action( 'woocommerce_order_status_completed', 'winshirt_register_lottery_participant' );
 
 // Register custom post type for mockups
 add_action('init', function () {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: shakass
 Tags: woocommerce, personnalisation, t-shirt, loterie
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 License: GPLv2 or later
 
 Plugin pour personnalisation de produits et loteries via WooCommerce.

--- a/templates/admin/partials/loteries-list.php
+++ b/templates/admin/partials/loteries-list.php
@@ -32,8 +32,7 @@
                 $end    = get_post_meta($lottery->ID, '_winshirt_lottery_end', true);
                 $product= get_post_meta($lottery->ID, '_winshirt_lottery_product', true);
                 $active = get_post_meta($lottery->ID, '_winshirt_lottery_active', true) === 'yes';
-                $parts  = get_post_meta($lottery->ID, '_winshirt_lottery_participants', true);
-                $count  = is_array($parts) ? count($parts) : 0;
+                $count  = absint(get_post_meta($lottery->ID, 'participants_count', true));
             ?>
             <tr>
                 <td><?php echo esc_html($lottery->post_title); ?></td>

--- a/winshirt.php
+++ b/winshirt.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WinShirt by Shakass
  * Description: Module de personnalisation produit et loteries pour WooCommerce.
- * Version: 1.0.1
+ * Version: 1.0.2
  * Author: Shakass Communication
  */
 


### PR DESCRIPTION
## Summary
- allow duplicate lottery selections on the product page
- record participant counts when orders move to processing or completed
- display participant counts in the lotteries admin list
- bump plugin version to 1.0.2

## Testing
- `php -l includes/init.php` *(fails: command not found)*
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6853b15fcdb883298db5033e52f164ea