### PR TITLE
Fix lottery selection and participant counting

### DIFF
--- a/assets/js/winshirt-lottery-selected.js
+++ b/assets/js/winshirt-lottery-selected.js
@@ -12,20 +12,15 @@ jQuery(function($){
   function renderAll(){
     $container.empty();
 
-    var added = {};
     var cardIndex = 0;
 
-    $selects.each(function(){
+    $selects.each(function(index){
       var $select = $(this);
       var $opt    = $select.find('option:selected');
       var lid     = $opt.val();
       if(!lid){
         return;
       }
-      if(added[lid]){
-        return; // avoid duplicate cards for same lottery
-      }
-      added[lid] = true;
 
       var data = $opt.data('info');
       if(typeof data === 'string'){
@@ -36,7 +31,7 @@ jQuery(function($){
       var percent = data.goal ? Math.min(100, Math.round((data.participants / data.goal) * 100)) : 0;
       var badge   = data.featured ? '<span class="loterie-badge">BEST</span>' : (data.active ? '<span class="loterie-badge">NOUVEAU</span>' : '');
       var price   = data.value ? '<span class="loterie-price">'+data.value+'€</span>' : '';
-      var html    = '<div class="loterie-card" id="loterie-card-'+cardIndex+'" data-index="'+cardIndex+'" data-lottery="'+lid+'">'+
+      var html    = '<div class="loterie-card" id="loterie-card-'+cardIndex+'" data-index="'+cardIndex+'" data-select-index="'+index+'" data-lottery="'+lid+'">'+
         badge+
         '<button type="button" class="loterie-remove" aria-label="Retirer">&times;</button>'+
         (data.image ? '<img class="loterie-img" src="'+data.image+'" alt="" />' : '')+

--- a/includes/init.php
+++ b/includes/init.php
@@ -466,10 +466,18 @@ function winshirt_register_lottery_participant( $order_id ) {
     foreach ( $order->get_items() as $item ) {
         $lotteries = $item->get_meta( '_winshirt_lotteries', true );
         if ( $lotteries ) {
+            $counts = [];
             foreach ( (array) $lotteries as $lottery_id ) {
-                $count     = absint( get_post_meta( $lottery_id, 'participants_count', true ) );
-                $increment = $item->get_quantity();
-                update_post_meta( $lottery_id, 'participants_count', $count + $increment );
+                if ( ! isset( $counts[ $lottery_id ] ) ) {
+                    $counts[ $lottery_id ] = 0;
+                }
+                $counts[ $lottery_id ]++;
+            }
+
+            foreach ( $counts as $lottery_id => $times ) {
+                $current   = absint( get_post_meta( $lottery_id, 'participants_count', true ) );
+                $increment = $item->get_quantity() * $times;
+                update_post_meta( $lottery_id, 'participants_count', $current + $increment );
             }
             continue;
         }


### PR DESCRIPTION
## Summary
- allow choosing the same lottery multiple times
- correct participant counter updates when several lotteries are selected

## Testing
- `node --check assets/js/winshirt-lottery-selected.js`

------
https://chatgpt.com/codex/tasks/task_e_6853e0b453b083298d8bc555a45f5352