### PR TITLE
Fix lottery duplication and removal logic

### DIFF
--- a/assets/js/winshirt-lottery-selected.js
+++ b/assets/js/winshirt-lottery-selected.js
@@ -9,11 +9,8 @@ jQuery(function($){
   var $container = $containers.first();
   var $selects   = $('.winshirt-lottery-select');
 
-  function renderAll(){
-    $container.empty();
-
-    var cardIndex = 0;
-
+  function getSelectedLotteries(){
+    var lots = [];
     $selects.each(function(index){
       var $select = $(this);
       var $opt    = $select.find('option:selected');
@@ -21,42 +18,72 @@ jQuery(function($){
       if(!lid){
         return;
       }
-
       var data = $opt.data('info');
       if(typeof data === 'string'){
         try{ data = JSON.parse(data); }catch(e){ data = {}; }
       }
       data = data || {};
+      lots.push({ id: lid, data: data, selectIndex: index, $select: $select, text: $opt.text() });
+    });
+    return lots;
+  }
 
-      var percent = data.goal ? Math.min(100, Math.round((data.participants / data.goal) * 100)) : 0;
-      var badge   = data.featured ? '<span class="loterie-badge">BEST</span>' : (data.active ? '<span class="loterie-badge">NOUVEAU</span>' : '');
-      var price   = data.value ? '<span class="loterie-price">'+data.value+'€</span>' : '';
-      var html    = '<div class="loterie-card" id="loterie-card-'+cardIndex+'" data-index="'+cardIndex+'" data-select-index="'+index+'" data-lottery="'+lid+'">'+
+  function getUniqueLoteries(loteries){
+    return loteries.filter(function(lot, idx, arr){
+      return arr.findIndex(function(l){ return l.id === lot.id; }) === idx;
+    });
+  }
+
+  function renderLoteries(loteries){
+    $container.empty();
+    loteries.forEach(function(lot, cardIndex){
+      var percent = lot.data.goal ? Math.min(100, Math.round((lot.data.participants / lot.data.goal) * 100)) : 0;
+      var badge   = lot.data.featured ? '<span class="loterie-badge">BEST</span>' : (lot.data.active ? '<span class="loterie-badge">NOUVEAU</span>' : '');
+      var price   = lot.data.value ? '<span class="loterie-price">'+lot.data.value+'€</span>' : '';
+      var html    = '<div class="loterie-card" data-index="'+cardIndex+'" data-lottery="'+lot.id+'">'+
         badge+
         '<button type="button" class="loterie-remove" aria-label="Retirer">&times;</button>'+
-        (data.image ? '<img class="loterie-img" src="'+data.image+'" alt="" />' : '')+
+        (lot.data.image ? '<img class="loterie-img" src="'+lot.data.image+'" alt="" />' : '')+
         '<div class="loterie-info">'+
-          '<span class="loterie-title">'+(data.name || $opt.text())+'</span>'+
+          '<span class="loterie-title">'+(lot.data.name || lot.text)+'</span>'+
           '<div class="loterie-meta">'+
             price+
-            '<span class="loterie-participants">'+data.participants+' / '+data.goal+' participants</span>'+
+            '<span class="loterie-participants">'+lot.data.participants+' / '+lot.data.goal+' participants</span>'+
           '</div>'+
           '<div class="loterie-bar-bg">'+
             '<div class="loterie-bar" style="width:'+percent+'%"></div>'+
-            '<div class="loterie-tooltip">'+percent+'% rempli ('+data.participants+' sur '+data.goal+')</div>'+
+            '<div class="loterie-tooltip">'+percent+'% rempli ('+lot.data.participants+' sur '+lot.data.goal+')</div>'+
           '</div>'+
         '</div>'+
       '</div>';
 
-      $container.append(html);
-      var $card = $container.find('#loterie-card-'+cardIndex);
+      var $card = $(html).appendTo($container);
       $card.find('.loterie-remove').on('click', function(e){
         e.preventDefault();
-        $select.val('');
-        renderAll();
+        removeLoterie(lot.id);
       });
-      cardIndex++;
     });
+  }
+
+  function removeLoterie(id){
+    $selects.each(function(){
+      var $select = $(this);
+      if($select.val() == id){
+        $select.val('');
+        if($select.data('select2')){
+          $select.trigger('change');
+        }else{
+          $select.trigger('input').trigger('change');
+        }
+      }
+    });
+    renderAll();
+  }
+
+  function renderAll(){
+    var selected = getSelectedLotteries();
+    var unique   = getUniqueLoteries(selected);
+    renderLoteries(unique);
   }
 
   $selects.on('change', renderAll);


### PR DESCRIPTION
## Summary
- deduplicate selected lotteries before rendering
- sync removing lottery cards with select elements

## Testing
- `node -e "require('fs').readFileSync('assets/js/winshirt-lottery-selected.js','utf8')"`

------
https://chatgpt.com/codex/tasks/task_e_6853f8da4be083298dffbe70650afcf6