### PR TITLE
Require lottery pick before adding to cart

### DIFF
--- a/assets/css/winshirt-lottery-selected.css
+++ b/assets/css/winshirt-lottery-selected.css
@@ -172,3 +172,5 @@
   .loterie-badge { left: 10px; top: 8px; font-size: 0.75rem; }
   .loterie-remove { top: 6px; right: 6px; width: 22px; height: 22px; font-size: 1.02rem; }
 }
+
+.winshirt-lottery-warning{color:#b91c1c;margin-top:.5em;font-size:.95rem;}

--- a/assets/js/winshirt-lottery-enforce.js
+++ b/assets/js/winshirt-lottery-enforce.js
@@ -1,0 +1,79 @@
+jQuery(function($){
+  var $selects = $('.winshirt-lottery-select');
+  var $button = $('.single_add_to_cart_button');
+  if(!$selects.length || !$button.length){
+    return;
+  }
+
+  var warningText = 'Aucune loterie s\xC3\xA9lectionn\xC3\xA9e : vous serez automatiquement inscrit(e) \xC3\xA0 la loterie la plus proche du tirage.';
+  var $warning = $('<p class="winshirt-lottery-warning"></p>').text(warningText);
+  $warning.insertAfter($button.first());
+
+  function anySelected(){
+    var ok = false;
+    $selects.each(function(){
+      var v = $(this).val();
+      if(v && v !== '0'){ ok = true; return false; }
+    });
+    return ok;
+  }
+
+  function updateState(){
+    if(anySelected()){
+      $button.prop('disabled', false);
+      $warning.hide();
+    }else{
+      $button.prop('disabled', true);
+      $warning.show();
+    }
+  }
+
+  function parseData($opt){
+    var data = $opt.data('info');
+    if(!data) return {};
+    if(typeof data === 'string'){
+      try{ data = JSON.parse(data); }catch(e){ data = {}; }
+    }
+    return data || {};
+  }
+
+  function getBestLottery(){
+    var best = null;
+    var bestRatio = -1;
+    var $options = $selects.eq(0).find('option');
+    $options.each(function(){
+      var $opt = $(this);
+      var val = $opt.val();
+      if(!val || val === '0') return;
+      var data = parseData($opt);
+      var goal = parseInt(data.goal || 0, 10);
+      var count = parseInt(data.participants || 0, 10);
+      if(goal > 0 && count >= goal) return;
+      var ratio = goal > 0 ? count / goal : 0;
+      if(ratio > bestRatio){
+        bestRatio = ratio;
+        best = val;
+      }
+    });
+    return best;
+  }
+
+  $selects.on('change', updateState);
+  updateState();
+
+  var submitting = false;
+  $('form.cart').on('submit', function(e){
+    if(submitting || anySelected()) return;
+    e.preventDefault();
+    var best = getBestLottery();
+    if(best){
+      $selects.each(function(){
+        if(!$(this).val()){
+          $(this).val(best).trigger('change');
+        }
+      });
+      submitting = true;
+      setTimeout(() => { $(this).trigger('submit'); }, 0);
+    }
+  });
+});

--- a/includes/init.php
+++ b/includes/init.php
@@ -12,6 +12,7 @@ add_action('wp_enqueue_scripts', function () {
 
         wp_enqueue_style('winshirt-lottery-selected', WINSHIRT_URL . 'assets/css/winshirt-lottery-selected.css', [], '1.0');
         wp_enqueue_script('winshirt-lottery-selected', WINSHIRT_URL . 'assets/js/winshirt-lottery-selected.js', ['jquery'], '1.0', true);
+        wp_enqueue_script('winshirt-lottery-enforce', WINSHIRT_URL . 'assets/js/winshirt-lottery-enforce.js', ['jquery'], '1.0', true);
     }
 });
 


### PR DESCRIPTION
## Summary
- disable add-to-cart when no lottery selected
- auto-assign most filled lottery if user submits without picking one
- style warning message about auto-assignment
- load new JS on product pages

## Testing
- `php -l includes/init.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685410fbe8b48329bec7105f07aad897