### PR TITLE
Fix lottery messages

### DIFF
--- a/assets/js/winshirt-lottery-enforce.js
+++ b/assets/js/winshirt-lottery-enforce.js
@@ -5,7 +5,7 @@ jQuery(function($){
     return;
   }
 
-  var warningText = 'Aucune loterie s\xC3\xA9lectionn\xC3\xA9e : vous serez automatiquement inscrit(e) \xC3\xA0 la loterie la plus proche du tirage.';
+  var warningText = 'Aucune loterie sélectionnée : vous serez automatiquement inscrit(e) à la loterie la plus proche du tirage.';
   var $warning = $('<p class="winshirt-lottery-warning"></p>').text(warningText);
   $warning.insertAfter($button.first());
 

--- a/includes/init.php
+++ b/includes/init.php
@@ -337,7 +337,7 @@ function winshirt_render_lottery_selector() {
     echo '<div class="winshirt-lottery-selects">';
     for ( $i = 1; $i <= $tickets; $i++ ) {
         echo '<div class="winshirt-lottery-select">';
-        echo '<label for="winshirt-lottery-select-' . $i . '">' . esc_html__( 'Choisissez votre loterie', 'winshirt' ) . ' #' . $i . '</label> ';
+        echo '<label for="winshirt-lottery-select-' . $i . '">' . esc_html__( 'Ticket n°', 'winshirt' ) . $i . '</label> ';
         echo '<select id="winshirt-lottery-select-' . $i . '" class="winshirt-lottery-select" name="winshirt_lotteries[]">';
         echo '<option value="">' . esc_html__( '-- Sélectionner --', 'winshirt' ) . '</option>';
         foreach ( $lotteries as $lottery ) {


### PR DESCRIPTION
## Summary
- update warning text with correct UTF-8 characters
- change lottery select label to "Ticket n°X"

## Testing
- `node -e "new Function(require('fs').readFileSync('assets/js/winshirt-lottery-enforce.js')); console.log('JS OK');"`
- `php -l includes/init.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68541de598f48329a18139d4f34c4a25