### PR TITLE
Fix modal CSS to match drag logic

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -218,7 +218,7 @@
   object-fit: contain;
 }
 .ws-canvas {
-  position: absolute;
+  position: relative;
   inset: 0;
 }
 .ws-item {
@@ -228,6 +228,8 @@
   border-radius: .25rem;
   cursor: move;
   transition: none;
+  box-sizing: border-box;
+  pointer-events: auto;
 }
 .ws-item .ui-resizable-handle {
   width: 8px;
@@ -347,8 +349,10 @@
 }
 .ws-print-zone {
   position: absolute;
+  z-index: 2;
   border: 1px dashed rgba(255,255,255,0.7);
   pointer-events: none;
+  overflow: hidden !important;
   display: none;
 }
 #ws-print-zones {


### PR DESCRIPTION
## Summary
- update position for `.ws-canvas`
- hide overflowing content in `.ws-print-zone`
- ensure draggable item respects bounds

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68552c11604483299f88b20ad23ae06f