### PR TITLE
Allow choosing mockup images from WordPress library

### DIFF
--- a/assets/js/winshirt-mockups.js
+++ b/assets/js/winshirt-mockups.js
@@ -1,4 +1,26 @@
 jQuery(function ($) {
+  function openMedia(target, preview) {
+    var frame = wp.media({
+      title: 'Choisir une image',
+      button: { text: 'Sélectionner' },
+      multiple: false
+    });
+    frame.on('select', function () {
+      var attachment = frame.state().get('selection').first().toJSON();
+      $('#' + target).val(attachment.id);
+      if (preview) {
+        $(preview).html('<img src="' + attachment.sizes.thumbnail.url + '" />');
+      }
+    });
+    frame.open();
+  }
+
+  $(document).on('click', '.winshirt-media-btn', function (e) {
+    e.preventDefault();
+    var target = $(this).data('target');
+    var preview = $(this).data('preview');
+    openMedia(target, preview);
+  });
   $('#add-color').on('click', function (e) {
     e.preventDefault();
     var index = $('#colors-container .color-row').length;

--- a/includes/init.php
+++ b/includes/init.php
@@ -206,6 +206,7 @@ add_action('admin_enqueue_scripts', function ($hook) {
         wp_enqueue_script('winshirt-admin', WINSHIRT_URL . 'assets/js/winshirt-admin.js', ['wp-element'], '1.0', true);
 
         if (strpos($hook, 'winshirt-mockups') !== false) {
+            wp_enqueue_media();
             wp_enqueue_style('winshirt-mockups', WINSHIRT_URL . 'assets/css/winshirt-mockups.css', [], '1.0');
             wp_enqueue_script('winshirt-mockups', WINSHIRT_URL . 'assets/js/winshirt-mockups.js', ['jquery', 'jquery-ui-draggable', 'jquery-ui-resizable'], '1.0', true);
         }

--- a/includes/pages/mockups.php
+++ b/includes/pages/mockups.php
@@ -36,18 +36,14 @@ function winshirt_page_mockups() {
 
         update_post_meta($mockup_id, '_winshirt_category', sanitize_text_field($_POST['category'] ?? ''));
 
-        if (!empty($_FILES['front_image']['tmp_name'])) {
-            $front_id = media_handle_upload('front_image', 0);
-            if (!is_wp_error($front_id)) {
-                update_post_meta($mockup_id, '_winshirt_front_image', $front_id);
-            }
+        $front_id = isset($_POST['front_image_id']) ? absint($_POST['front_image_id']) : 0;
+        if ($front_id) {
+            update_post_meta($mockup_id, '_winshirt_front_image', $front_id);
         }
 
-        if (!empty($_FILES['back_image']['tmp_name'])) {
-            $back_id = media_handle_upload('back_image', 0);
-            if (!is_wp_error($back_id)) {
-                update_post_meta($mockup_id, '_winshirt_back_image', $back_id);
-            }
+        $back_id = isset($_POST['back_image_id']) ? absint($_POST['back_image_id']) : 0;
+        if ($back_id) {
+            update_post_meta($mockup_id, '_winshirt_back_image', $back_id);
         }
 
         // Colors
@@ -63,20 +59,10 @@ function winshirt_page_mockups() {
                     'front' => 0,
                     'back'  => 0,
                 ];
-                if (!empty($_FILES['color_front_' . $idx]['tmp_name'])) {
-                    $fid = media_handle_upload('color_front_' . $idx, 0);
-                    if (!is_wp_error($fid)) {
-                        $c['front'] = $fid;
-                    }
-                } elseif (!empty($cdata['front'])) {
+                if (!empty($cdata['front'])) {
                     $c['front'] = absint($cdata['front']);
                 }
-                if (!empty($_FILES['color_back_' . $idx]['tmp_name'])) {
-                    $bid = media_handle_upload('color_back_' . $idx, 0);
-                    if (!is_wp_error($bid)) {
-                        $c['back'] = $bid;
-                    }
-                } elseif (!empty($cdata['back'])) {
+                if (!empty($cdata['back'])) {
                     $c['back'] = absint($cdata['back']);
                 }
                 if ($c['name']) {

--- a/templates/admin/partials/mockups-list.php
+++ b/templates/admin/partials/mockups-list.php
@@ -52,15 +52,19 @@
         <tr>
             <th><?php esc_html_e('Image recto', 'winshirt'); ?></th>
             <td>
-                <input type="file" name="front_image" />
-                <?php $front = $editing->ID ? get_post_meta($editing->ID, '_winshirt_front_image', true) : ''; if ($front) echo wp_get_attachment_image($front, 'thumbnail'); ?>
+                <?php $front = $editing->ID ? get_post_meta($editing->ID, '_winshirt_front_image', true) : ''; ?>
+                <input type="hidden" id="front_image_id" name="front_image_id" value="<?php echo esc_attr($front); ?>" />
+                <button type="button" class="button winshirt-media-btn" data-target="front_image_id" data-preview="#front_image_preview"><?php echo $front ? esc_html__('Modifier', 'winshirt') : esc_html__('Choisir', 'winshirt'); ?></button>
+                <span id="front_image_preview"><?php if ($front) echo wp_get_attachment_image($front, 'thumbnail'); ?></span>
             </td>
         </tr>
         <tr>
             <th><?php esc_html_e('Image verso', 'winshirt'); ?></th>
             <td>
-                <input type="file" name="back_image" />
-                <?php $back = $editing->ID ? get_post_meta($editing->ID, '_winshirt_back_image', true) : ''; if ($back) echo wp_get_attachment_image($back, 'thumbnail'); ?>
+                <?php $back = $editing->ID ? get_post_meta($editing->ID, '_winshirt_back_image', true) : ''; ?>
+                <input type="hidden" id="back_image_id" name="back_image_id" value="<?php echo esc_attr($back); ?>" />
+                <button type="button" class="button winshirt-media-btn" data-target="back_image_id" data-preview="#back_image_preview"><?php echo $back ? esc_html__('Modifier', 'winshirt') : esc_html__('Choisir', 'winshirt'); ?></button>
+                <span id="back_image_preview"><?php if ($back) echo wp_get_attachment_image($back, 'thumbnail'); ?></span>
             </td>
         </tr>
     </table>
@@ -73,12 +77,18 @@
         foreach ($colors as $c) : ?>
             <div class="color-row">
                 <button class="remove-color button">&times;</button>
-                <input type="hidden" name="colors[<?php echo $index; ?>][front]" value="<?php echo esc_attr($c['front']); ?>" />
-                <input type="hidden" name="colors[<?php echo $index; ?>][back]" value="<?php echo esc_attr($c['back']); ?>" />
+                <input type="hidden" id="color_front_<?php echo $index; ?>" name="colors[<?php echo $index; ?>][front]" value="<?php echo esc_attr($c['front']); ?>" />
+                <input type="hidden" id="color_back_<?php echo $index; ?>" name="colors[<?php echo $index; ?>][back]" value="<?php echo esc_attr($c['back']); ?>" />
                 <label><?php esc_html_e('Nom', 'winshirt'); ?> <input type="text" name="colors[<?php echo $index; ?>][name]" value="<?php echo esc_attr($c['name']); ?>" /></label>
                 <label><?php esc_html_e('Code', 'winshirt'); ?> <input type="color" name="colors[<?php echo $index; ?>][code]" value="<?php echo esc_attr($c['code']); ?>" /></label>
-                <label><?php esc_html_e('Image recto', 'winshirt'); ?> <input type="file" name="color_front_<?php echo $index; ?>" /><?php if ($c['front']) echo wp_get_attachment_image($c['front'], 'thumbnail'); ?></label>
-                <label><?php esc_html_e('Image verso', 'winshirt'); ?> <input type="file" name="color_back_<?php echo $index; ?>" /><?php if ($c['back']) echo wp_get_attachment_image($c['back'], 'thumbnail'); ?></label>
+                <label><?php esc_html_e('Image recto', 'winshirt'); ?>
+                    <button type="button" class="button winshirt-media-btn" data-target="color_front_<?php echo $index; ?>" data-preview="#color_front_preview_<?php echo $index; ?>"><?php echo $c['front'] ? esc_html__('Modifier', 'winshirt') : esc_html__('Choisir', 'winshirt'); ?></button>
+                    <span id="color_front_preview_<?php echo $index; ?>"><?php if ($c['front']) echo wp_get_attachment_image($c['front'], 'thumbnail'); ?></span>
+                </label>
+                <label><?php esc_html_e('Image verso', 'winshirt'); ?>
+                    <button type="button" class="button winshirt-media-btn" data-target="color_back_<?php echo $index; ?>" data-preview="#color_back_preview_<?php echo $index; ?>"><?php echo $c['back'] ? esc_html__('Modifier', 'winshirt') : esc_html__('Choisir', 'winshirt'); ?></button>
+                    <span id="color_back_preview_<?php echo $index; ?>"><?php if ($c['back']) echo wp_get_attachment_image($c['back'], 'thumbnail'); ?></span>
+                </label>
             </div>
         <?php $index++; endforeach; ?>
     </div>
@@ -86,12 +96,18 @@
     <script type="text/template" id="color-template">
         <div class="color-row">
             <button class="remove-color button">&times;</button>
-            <input type="hidden" name="colors[%i%][front]" value="" />
-            <input type="hidden" name="colors[%i%][back]" value="" />
+            <input type="hidden" id="color_front_%i%" name="colors[%i%][front]" value="" />
+            <input type="hidden" id="color_back_%i%" name="colors[%i%][back]" value="" />
             <label><?php esc_html_e('Nom', 'winshirt'); ?> <input type="text" name="colors[%i%][name]" value="" /></label>
             <label><?php esc_html_e('Code', 'winshirt'); ?> <input type="color" name="colors[%i%][code]" value="#000000" /></label>
-            <label><?php esc_html_e('Image recto', 'winshirt'); ?> <input type="file" name="color_front_%i%" /></label>
-            <label><?php esc_html_e('Image verso', 'winshirt'); ?> <input type="file" name="color_back_%i%" /></label>
+            <label><?php esc_html_e('Image recto', 'winshirt'); ?>
+                <button type="button" class="button winshirt-media-btn" data-target="color_front_%i%" data-preview="#color_front_preview_%i%">Choisir</button>
+                <span id="color_front_preview_%i%"></span>
+            </label>
+            <label><?php esc_html_e('Image verso', 'winshirt'); ?>
+                <button type="button" class="button winshirt-media-btn" data-target="color_back_%i%" data-preview="#color_back_preview_%i%">Choisir</button>
+                <span id="color_back_preview_%i%"></span>
+            </label>
         </div>
     </script>
     <h3><?php esc_html_e('Zones d\'impression', 'winshirt'); ?></h3>


### PR DESCRIPTION
## Summary
- enable media modal on the mockups admin page
- store selected attachment IDs for mockup images and color variants

## Testing
- `php -l includes/init.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c52fb163c8329bd8f50885afa46f4