### PR TITLE
Implement overlay-based color system

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -217,6 +217,13 @@
   max-height: 100%;
   object-fit: contain;
 }
+.ws-color-overlay {
+  position: absolute;
+  inset: 0;
+  mix-blend-mode: multiply;
+  pointer-events: none;
+  z-index: 1;
+}
 .ws-canvas {
   position: absolute;
   inset: 0;
@@ -330,6 +337,18 @@
 .ws-color-btn.active {
   outline: 2px solid #fff;
   opacity: 1;
+}
+.ws-product-colors {
+  display: flex;
+  gap: .25rem;
+  margin-bottom: .5rem;
+}
+.ws-product-color-overlay {
+  position: absolute;
+  inset: 0;
+  mix-blend-mode: multiply;
+  pointer-events: none;
+  z-index: 1;
 }
 .ws-format-buttons {
   display: flex;

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -3,7 +3,7 @@ jQuery(function($){
   if(!$modal.length) return;
   $('body').append($modal);
 
-  var state = {side:'front'};
+  var state = {side:'front', color:null};
   var $canvas = $('#ws-canvas');
   var $previewImg = $modal.find('.ws-preview-img');
   var initialFront = $modal.data('default-front');
@@ -124,6 +124,7 @@ jQuery(function($){
     });
     var data = {
       items: items,
+      color: state.color,
       defaultFront: $modal.data('default-front') || initialFront,
       defaultBack: $modal.data('default-back') || initialBack,
       side: state.side
@@ -138,6 +139,10 @@ jQuery(function($){
     $canvas.empty();
     if(raw.defaultFront){ $modal.data('default-front', raw.defaultFront); }
     if(raw.defaultBack){ $modal.data('default-back', raw.defaultBack); }
+    if(raw.color){
+      $('.ws-color-overlay').css('background-color', raw.color);
+      state.color = raw.color;
+    }
     switchSide(raw.side || 'front');
     if(Array.isArray(raw.items)){
       raw.items.forEach(function(it){
@@ -205,8 +210,8 @@ jQuery(function($){
     if(!col) return;
     $colorsWrap.find('.ws-color-btn').removeClass('active');
     $(this).addClass('active');
-    if(col.front){ $modal.data('default-front', col.front); if(state.side==='front') $previewImg.attr('src', col.front); }
-    if(col.back){ $modal.data('default-back', col.back); if(state.side==='back') $previewImg.attr('src', col.back); }
+    $('.ws-color-overlay').css('background-color', col.code || '#ffffff');
+    state.color = col.code || null;
     saveState();
   });
 
@@ -321,6 +326,7 @@ jQuery(function($){
 function openModal(){
   checkMobile();
   loadState();
+  if(state.color){ $('.ws-color-overlay').css('background-color', state.color); }
   $modal.removeClass('hidden').addClass('open');
   if (!$modal.hasClass('ws-mobile')) {
     setTimeout(function(){ $modal.find('.ws-right').addClass('show'); }, 10);
@@ -376,6 +382,8 @@ function openModal(){
     $modal.data('default-back', initialBack);
     $previewImg.attr('src', state.side === 'back' ? initialBack : initialFront);
     $colorsWrap.find('.ws-color-btn').removeClass('active');
+    $('.ws-color-overlay').css('background-color', 'transparent');
+    state.color = null;
     selectItem(null);
     saveState();
   });

--- a/includes/init.php
+++ b/includes/init.php
@@ -242,10 +242,8 @@ function winshirt_render_customize_button() {
     $colors      = [];
     foreach ( $colors_meta as $c ) {
         $colors[] = [
-            'name'  => $c['name'] ?? '',
-            'code'  => $c['code'] ?? '',
-            'front' => ! empty( $c['front'] ) ? wp_get_attachment_image_url( $c['front'], 'full' ) : '',
-            'back'  => ! empty( $c['back'] ) ? wp_get_attachment_image_url( $c['back'], 'full' ) : '',
+            'name' => $c['name'] ?? '',
+            'code' => $c['code'] ?? '',
         ];
     }
 
@@ -307,6 +305,48 @@ function winshirt_render_customize_button() {
     include WINSHIRT_PATH . 'templates/personalizer-modal.php';
 }
 add_action( 'woocommerce_single_product_summary', 'winshirt_render_customize_button', 35 );
+
+function winshirt_render_color_picker() {
+    global $product;
+    if ( ! $product instanceof WC_Product ) {
+        return;
+    }
+    $pid       = $product->get_id();
+    $front_id  = absint( get_post_meta( $pid, '_winshirt_default_mockup_front', true ) );
+    if ( ! $front_id ) {
+        return;
+    }
+    $colors = get_post_meta( $front_id, '_winshirt_colors', true );
+    $colors = is_array( $colors ) ? $colors : [];
+    if ( ! $colors ) {
+        return;
+    }
+    echo '<div class="ws-product-colors">';
+    foreach ( $colors as $c ) {
+        $code = esc_attr( $c['code'] ?? '' );
+        echo '<button class="ws-color-btn" data-color="' . $code . '" style="background-color:' . $code . '"></button>';
+    }
+    echo '</div>';
+    ?>
+    <script type="text/javascript">
+    jQuery(function($){
+        var $imgWrap = $('.woocommerce-product-gallery__image').eq(0);
+        if(!$imgWrap.length) return;
+        if(!$imgWrap.find('.ws-product-color-overlay').length){
+            $imgWrap.css('position','relative');
+            $('<div class="ws-product-color-overlay"></div>').appendTo($imgWrap);
+        }
+        $('.ws-product-colors').on('click', '.ws-color-btn', function(){
+            $('.ws-product-colors .ws-color-btn').removeClass('active');
+            $(this).addClass('active');
+            var col = $(this).data('color') || 'transparent';
+            $imgWrap.find('.ws-product-color-overlay').css('background-color', col);
+        });
+    });
+    </script>
+    <?php
+}
+add_action( 'woocommerce_single_product_summary', 'winshirt_render_color_picker', 34 );
 
 function winshirt_render_lottery_selector() {
     static $rendered = false;

--- a/includes/pages/mockups.php
+++ b/includes/pages/mockups.php
@@ -53,20 +53,13 @@ function winshirt_page_mockups() {
                 if (isset($cdata['remove']) && $cdata['remove']) {
                     continue;
                 }
-                $c = [
-                    'name' => sanitize_text_field($cdata['name'] ?? ''),
-                    'code' => sanitize_text_field($cdata['code'] ?? ''),
-                    'front' => 0,
-                    'back'  => 0,
-                ];
-                if (!empty($cdata['front'])) {
-                    $c['front'] = absint($cdata['front']);
-                }
-                if (!empty($cdata['back'])) {
-                    $c['back'] = absint($cdata['back']);
-                }
-                if ($c['name']) {
-                    $colors[] = $c;
+                $name = sanitize_text_field($cdata['name'] ?? '');
+                $code = sanitize_text_field($cdata['code'] ?? '');
+                if ($name) {
+                    $colors[] = [
+                        'name' => $name,
+                        'code' => $code,
+                    ];
                 }
             }
         }

--- a/templates/admin/partials/mockups-list.php
+++ b/templates/admin/partials/mockups-list.php
@@ -77,18 +77,8 @@
         foreach ($colors as $c) : ?>
             <div class="color-row">
                 <button class="remove-color button">&times;</button>
-                <input type="hidden" id="color_front_<?php echo $index; ?>" name="colors[<?php echo $index; ?>][front]" value="<?php echo esc_attr($c['front']); ?>" />
-                <input type="hidden" id="color_back_<?php echo $index; ?>" name="colors[<?php echo $index; ?>][back]" value="<?php echo esc_attr($c['back']); ?>" />
                 <label><?php esc_html_e('Nom', 'winshirt'); ?> <input type="text" name="colors[<?php echo $index; ?>][name]" value="<?php echo esc_attr($c['name']); ?>" /></label>
                 <label><?php esc_html_e('Code', 'winshirt'); ?> <input type="color" name="colors[<?php echo $index; ?>][code]" value="<?php echo esc_attr($c['code']); ?>" /></label>
-                <label><?php esc_html_e('Image recto', 'winshirt'); ?>
-                    <button type="button" class="button winshirt-media-btn" data-target="color_front_<?php echo $index; ?>" data-preview="#color_front_preview_<?php echo $index; ?>"><?php echo $c['front'] ? esc_html__('Modifier', 'winshirt') : esc_html__('Choisir', 'winshirt'); ?></button>
-                    <span id="color_front_preview_<?php echo $index; ?>"><?php if ($c['front']) echo wp_get_attachment_image($c['front'], 'thumbnail'); ?></span>
-                </label>
-                <label><?php esc_html_e('Image verso', 'winshirt'); ?>
-                    <button type="button" class="button winshirt-media-btn" data-target="color_back_<?php echo $index; ?>" data-preview="#color_back_preview_<?php echo $index; ?>"><?php echo $c['back'] ? esc_html__('Modifier', 'winshirt') : esc_html__('Choisir', 'winshirt'); ?></button>
-                    <span id="color_back_preview_<?php echo $index; ?>"><?php if ($c['back']) echo wp_get_attachment_image($c['back'], 'thumbnail'); ?></span>
-                </label>
             </div>
         <?php $index++; endforeach; ?>
     </div>
@@ -96,18 +86,8 @@
     <script type="text/template" id="color-template">
         <div class="color-row">
             <button class="remove-color button">&times;</button>
-            <input type="hidden" id="color_front_%i%" name="colors[%i%][front]" value="" />
-            <input type="hidden" id="color_back_%i%" name="colors[%i%][back]" value="" />
             <label><?php esc_html_e('Nom', 'winshirt'); ?> <input type="text" name="colors[%i%][name]" value="" /></label>
             <label><?php esc_html_e('Code', 'winshirt'); ?> <input type="color" name="colors[%i%][code]" value="#000000" /></label>
-            <label><?php esc_html_e('Image recto', 'winshirt'); ?>
-                <button type="button" class="button winshirt-media-btn" data-target="color_front_%i%" data-preview="#color_front_preview_%i%">Choisir</button>
-                <span id="color_front_preview_%i%"></span>
-            </label>
-            <label><?php esc_html_e('Image verso', 'winshirt'); ?>
-                <button type="button" class="button winshirt-media-btn" data-target="color_back_%i%" data-preview="#color_back_preview_%i%">Choisir</button>
-                <span id="color_back_preview_%i%"></span>
-            </label>
         </div>
     </script>
     <h3><?php esc_html_e('Zones d\'impression', 'winshirt'); ?></h3>

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -10,6 +10,7 @@
     <div class="ws-left">
       <div class="ws-preview mockup-fixed">
         <img src="<?php echo esc_url( $default_front ?? '' ); ?>" alt="Mockup" class="ws-preview-img" />
+        <div class="ws-color-overlay"></div>
         <div id="ws-canvas" class="ws-canvas"></div>
         <div id="ws-print-zones"></div>
       </div>


### PR DESCRIPTION
## Summary
- remove color image uploads from admin mockup page
- store only name and hex code for mockup colors
- add overlay for mockup preview in modal
- enable product page color selection with overlay

## Testing
- `php` not installed; unable to run syntax checks

------
https://chatgpt.com/codex/tasks/task_e_685d645bff7c832998e511736dfebcc4