### PR TITLE
Improve WinShirt styles and external modal trigger

### DIFF
--- a/assets/css/winshirt-lottery-selected.css
+++ b/assets/css/winshirt-lottery-selected.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   gap: 22px;
   max-width: 640px;
-  margin: auto;
+  margin: 10px auto 0;
 }
 
 .loterie-card {
@@ -173,4 +173,4 @@
   .loterie-remove { top: 6px; right: 6px; width: 22px; height: 22px; font-size: 1.02rem; }
 }
 
-.winshirt-lottery-warning{color:#b91c1c;margin-top:.5em;font-size:.95rem;}
+.winshirt-lottery-warning{color:#b91c1c;margin-top:10px;font-size:.95rem;}

--- a/assets/css/winshirt-lottery.css
+++ b/assets/css/winshirt-lottery.css
@@ -128,3 +128,7 @@
 .lottery-progress-bar.animate-progress {
   animation: progress-fill 1s forwards;
 }
+
+.winshirt-lottery-select {
+  margin-bottom: 10px;
+}

--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -349,6 +349,7 @@
   mix-blend-mode: multiply;
   pointer-events: none;
   z-index: 1;
+  background-color: transparent;
 }
 .ws-format-buttons {
   display: flex;

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -337,6 +337,10 @@ function openModal(){
   debugHiddenElements();
 }
 
+  window.openWinShirtModal = function(productId){
+    openModal();
+  };
+
   function openTab(tab){
     if($modal.hasClass('ws-mobile')){
       var $c = $('#ws-tab-'+tab);

--- a/includes/init.php
+++ b/includes/init.php
@@ -269,7 +269,7 @@ function winshirt_render_customize_button() {
         }
     }
 
-    echo '<button id="winshirt-open-modal" class="button">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button>';
+    echo '<button id="winshirt-open-modal" class="button single_add_to_cart_button">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button>';
     $default_front = $front_url;
     $default_back  = $back_url;
     $ws_colors     = wp_json_encode( $colors );
@@ -332,9 +332,19 @@ function winshirt_render_color_picker() {
     jQuery(function($){
         var $imgWrap = $('.woocommerce-product-gallery__image').eq(0);
         if(!$imgWrap.length) return;
+        var imgSrc = $imgWrap.find('img').attr('src') || '';
         if(!$imgWrap.find('.ws-product-color-overlay').length){
             $imgWrap.css('position','relative');
-            $('<div class="ws-product-color-overlay"></div>').appendTo($imgWrap);
+            $('<div class="ws-product-color-overlay"></div>').css({
+                '-webkit-mask-image':'url('+imgSrc+')',
+                'mask-image':'url('+imgSrc+')',
+                '-webkit-mask-size':'contain',
+                'mask-size':'contain',
+                '-webkit-mask-repeat':'no-repeat',
+                'mask-repeat':'no-repeat',
+                '-webkit-mask-position':'center',
+                'mask-position':'center'
+            }).appendTo($imgWrap);
         }
         $('.ws-product-colors').on('click', '.ws-color-btn', function(){
             $('.ws-product-colors .ws-color-btn').removeClass('active');
@@ -377,9 +387,9 @@ function winshirt_render_lottery_selector() {
 
     echo '<div class="winshirt-lottery-selects">';
     for ( $i = 1; $i <= $tickets; $i++ ) {
-        echo '<div class="winshirt-lottery-select">';
+        echo '<div class="form-row form-row-wide winshirt-lottery-select">';
         echo '<label for="winshirt-lottery-select-' . $i . '">' . esc_html__( 'Ticket n°', 'winshirt' ) . $i . '</label> ';
-        echo '<select id="winshirt-lottery-select-' . $i . '" class="winshirt-lottery-select" name="winshirt_lotteries[]">';
+        echo '<select id="winshirt-lottery-select-' . $i . '" class="winshirt-lottery-select select" name="winshirt_lotteries[]">';
         echo '<option value="">' . esc_html__( '-- Sélectionner --', 'winshirt' ) . '</option>';
         foreach ( $lotteries as $lottery ) {
             $max       = absint( get_post_meta( $lottery->ID, 'max_participants', true ) );

--- a/readme.txt
+++ b/readme.txt
@@ -23,3 +23,10 @@ Une page "Loteries" permet de créer et d'administrer les tirages. Chaque loteri
 * `[loterie_box id="123" vedette="true"]` – carte individuelle de loterie avec tous les détails.
 * `[winshirt_lotteries]` – liste de toutes les loteries sous forme de cartes.
 * `[loterie_thumb id="123"]` – uniquement l'image miniature.
+
+## Ouverture du modale via JavaScript
+Ajoutez un bouton personnalisé et appelez la fonction suivante pour afficher la personnalisation :
+
+```
+<button onclick="openWinShirtModal(123)">Personnaliser</button>
+```

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -3,7 +3,8 @@
   data-default-back="<?php echo esc_attr( $default_back ?? '' ); ?>"
   data-colors='<?php echo esc_attr( $ws_colors ?? '[]' ); ?>'
   data-zones='<?php echo esc_attr( $ws_zones ?? '[]' ); ?>'
-  data-gallery='<?php echo esc_attr( $ws_gallery ?? '[]' ); ?>'>
+  data-gallery='<?php echo esc_attr( $ws_gallery ?? '[]' ); ?>'
+  data-product-id="<?php echo esc_attr( $pid ); ?>">
   
   <div class="ws-modal-content">
 


### PR DESCRIPTION
## Summary
- align plugin fields and buttons with WooCommerce classes
- fix lottery select spacing and warning margins
- refine mockup color overlay with mask
- expose `openWinShirtModal()` JS helper
- document JS usage in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685e319c3928832990c71c8a5967ec5a