### PR TITLE
Improve WooCommerce theme integration

### DIFF
--- a/assets/css/winshirt-lottery-selected.css
+++ b/assets/css/winshirt-lottery-selected.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   gap: 22px;
   max-width: 640px;
-  margin: 10px auto 0;
+  margin: 1rem auto 0;
 }
 
 .loterie-card {
@@ -173,4 +173,8 @@
   .loterie-remove { top: 6px; right: 6px; width: 22px; height: 22px; font-size: 1.02rem; }
 }
 
-.winshirt-lottery-warning{color:#b91c1c;margin-top:10px;font-size:.95rem;}
+.winshirt-lottery-warning{
+  color:#b91c1c;
+  margin: .5rem 0 1rem;
+  font-size:.95rem;
+}

--- a/assets/css/winshirt-lottery.css
+++ b/assets/css/winshirt-lottery.css
@@ -130,5 +130,5 @@
 }
 
 .winshirt-lottery-select {
-  margin-bottom: 10px;
+  margin-bottom: 1rem;
 }

--- a/assets/css/winshirt-theme.css
+++ b/assets/css/winshirt-theme.css
@@ -1,0 +1,11 @@
+.winshirt-theme-inherit {
+  font-family: inherit;
+  color: inherit;
+  transition: all .3s ease;
+}
+
+.winshirt-lottery-selects {
+  margin-bottom: 1rem;
+}
+
+

--- a/assets/js/winshirt-lottery-selected.js
+++ b/assets/js/winshirt-lottery-selected.js
@@ -40,11 +40,11 @@ jQuery(function($){
       var percent = lot.data.goal ? Math.min(100, Math.round((lot.data.participants / lot.data.goal) * 100)) : 0;
       var badge   = lot.data.featured ? '<span class="loterie-badge">BEST</span>' : (lot.data.active ? '<span class="loterie-badge">NOUVEAU</span>' : '');
       var price   = lot.data.value ? '<span class="loterie-price">'+lot.data.value+'€</span>' : '';
-      var html    = '<div class="loterie-card" data-index="'+cardIndex+'" data-lottery="'+lot.id+'">'+
+      var html    = '<div class="loterie-card winshirt-theme-inherit" data-index="'+cardIndex+'" data-lottery="'+lot.id+'">'+
         badge+
-        '<button type="button" class="loterie-remove" aria-label="Retirer">&times;</button>'+
-        (lot.data.image ? '<img class="loterie-img" src="'+lot.data.image+'" alt="" />' : '')+
-        '<div class="loterie-info">'+
+        '<button type="button" class="loterie-remove winshirt-theme-inherit" aria-label="Retirer">&times;</button>'+
+        (lot.data.image ? '<img class="loterie-img winshirt-theme-inherit" src="'+lot.data.image+'" alt="" />' : '')+
+        '<div class="loterie-info winshirt-theme-inherit">'+
           '<span class="loterie-title">'+(lot.data.name || lot.text)+'</span>'+
           '<div class="loterie-meta">'+
             price+

--- a/includes/init.php
+++ b/includes/init.php
@@ -6,6 +6,7 @@ add_action('wp_enqueue_scripts', function () {
     if (is_product()) {
         wp_enqueue_style('winshirt-modal', WINSHIRT_URL . 'assets/css/winshirt-modal.css', [], '1.0');
         wp_enqueue_style('winshirt-lottery', WINSHIRT_URL . 'assets/css/winshirt-lottery.css', [], '1.0');
+        wp_enqueue_style('winshirt-theme', WINSHIRT_URL . 'assets/css/winshirt-theme.css', [], '1.0');
 
         wp_enqueue_script('winshirt-touch', WINSHIRT_URL . 'assets/js/jquery.ui.touch-punch.min.js', ['jquery', 'jquery-ui-mouse'], '0.2.3', true);
         wp_enqueue_script('winshirt-modal', WINSHIRT_URL . 'assets/js/winshirt-modal.js', ['jquery', 'jquery-ui-draggable', 'jquery-ui-resizable', 'winshirt-touch'], '1.0', true);
@@ -269,7 +270,7 @@ function winshirt_render_customize_button() {
         }
     }
 
-    echo '<button id="winshirt-open-modal" class="button single_add_to_cart_button">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button>';
+    echo '<button id="winshirt-open-modal" class="button single_add_to_cart_button winshirt-theme-inherit">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button>';
     $default_front = $front_url;
     $default_back  = $back_url;
     $ws_colors     = wp_json_encode( $colors );
@@ -316,42 +317,37 @@ function winshirt_render_color_picker() {
     if ( ! $front_id ) {
         return;
     }
-    $colors = get_post_meta( $front_id, '_winshirt_colors', true );
-    $colors = is_array( $colors ) ? $colors : [];
-    if ( ! $colors ) {
+    $img_url = get_the_post_thumbnail_url( $front_id, 'full' );
+    if ( ! $img_url ) {
         return;
     }
-    echo '<div class="ws-product-colors">';
-    foreach ( $colors as $c ) {
-        $code = esc_attr( $c['code'] ?? '' );
-        echo '<button class="ws-color-btn" data-color="' . $code . '" style="background-color:' . $code . '"></button>';
-    }
-    echo '</div>';
     ?>
     <script type="text/javascript">
     jQuery(function($){
         var $imgWrap = $('.woocommerce-product-gallery__image').eq(0);
         if(!$imgWrap.length) return;
-        var imgSrc = $imgWrap.find('img').attr('src') || '';
+        var imgSrc = $imgWrap.find('img').attr('src') || <?php echo wp_json_encode( $img_url ); ?>;
         if(!$imgWrap.find('.ws-product-color-overlay').length){
             $imgWrap.css('position','relative');
-            $('<div class="ws-product-color-overlay"></div>').css({
+            $('<div class="ws-product-color-overlay winshirt-theme-inherit"></div>').css({
                 '-webkit-mask-image':'url('+imgSrc+')',
                 'mask-image':'url('+imgSrc+')',
-                '-webkit-mask-size':'contain',
-                'mask-size':'contain',
+                '-webkit-mask-size':'100% 100%',
+                'mask-size':'100% 100%',
+                'background-size':'100% 100%',
                 '-webkit-mask-repeat':'no-repeat',
                 'mask-repeat':'no-repeat',
                 '-webkit-mask-position':'center',
                 'mask-position':'center'
             }).appendTo($imgWrap);
         }
-        $('.ws-product-colors').on('click', '.ws-color-btn', function(){
-            $('.ws-product-colors .ws-color-btn').removeClass('active');
-            $(this).addClass('active');
-            var col = $(this).data('color') || 'transparent';
-            $imgWrap.find('.ws-product-color-overlay').css('background-color', col);
-        });
+        var stored = localStorage.getItem('winshirt_custom');
+        if(stored){
+            try{ stored = JSON.parse(stored); }catch(e){ stored = null; }
+            if(stored && stored.color){
+                $imgWrap.find('.ws-product-color-overlay').css('background-color', stored.color);
+            }
+        }
     });
     </script>
     <?php
@@ -385,11 +381,11 @@ function winshirt_render_lottery_selector() {
         return;
     }
 
-    echo '<div class="winshirt-lottery-selects">';
+    echo '<div class="winshirt-lottery-selects winshirt-theme-inherit">';
     for ( $i = 1; $i <= $tickets; $i++ ) {
-        echo '<div class="form-row form-row-wide winshirt-lottery-select">';
-        echo '<label for="winshirt-lottery-select-' . $i . '">' . esc_html__( 'Ticket n°', 'winshirt' ) . $i . '</label> ';
-        echo '<select id="winshirt-lottery-select-' . $i . '" class="winshirt-lottery-select select" name="winshirt_lotteries[]">';
+        echo '<div class="form-row form-row-wide winshirt-lottery-select winshirt-theme-inherit">';
+        echo '<label class="winshirt-theme-inherit" for="winshirt-lottery-select-' . $i . '">' . esc_html__( 'Ticket n°', 'winshirt' ) . $i . '</label> ';
+        echo '<select id="winshirt-lottery-select-' . $i . '" class="winshirt-lottery-select select winshirt-theme-inherit" name="winshirt_lotteries[]">';
         echo '<option value="">' . esc_html__( '-- Sélectionner --', 'winshirt' ) . '</option>';
         foreach ( $lotteries as $lottery ) {
             $max       = absint( get_post_meta( $lottery->ID, 'max_participants', true ) );

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -1,4 +1,4 @@
-<div id="winshirt-customizer-modal" class="ws-modal hidden"
+<div id="winshirt-customizer-modal" class="ws-modal hidden winshirt-theme-inherit"
   data-default-front="<?php echo esc_attr( $default_front ?? '' ); ?>"
   data-default-back="<?php echo esc_attr( $default_back ?? '' ); ?>"
   data-colors='<?php echo esc_attr( $ws_colors ?? '[]' ); ?>'
@@ -6,47 +6,47 @@
   data-gallery='<?php echo esc_attr( $ws_gallery ?? '[]' ); ?>'
   data-product-id="<?php echo esc_attr( $pid ); ?>">
   
-  <div class="ws-modal-content">
+  <div class="ws-modal-content winshirt-theme-inherit">
 
-    <div class="ws-left">
-      <div class="ws-preview mockup-fixed">
+    <div class="ws-left winshirt-theme-inherit">
+      <div class="ws-preview mockup-fixed winshirt-theme-inherit">
         <img src="<?php echo esc_url( $default_front ?? '' ); ?>" alt="Mockup" class="ws-preview-img" />
-        <div class="ws-color-overlay"></div>
+        <div class="ws-color-overlay winshirt-theme-inherit"></div>
         <div id="ws-canvas" class="ws-canvas"></div>
         <div id="ws-print-zones"></div>
       </div>
     </div>
 
-    <div class="ws-right">
-      <div class="ws-tabs-header">
-        <button class="ws-tab-button active" data-tab="gallery">🖼 Galerie</button>
-        <button class="ws-tab-button" data-tab="text">🔤 Texte</button>
-        <button class="ws-tab-button" data-tab="ai">🤖 IA</button>
-        <button class="ws-tab-button" data-tab="svg">✒️ SVG</button>
-        <button id="ws-reset-visual" class="ws-reset">Réinitialiser ↺</button>
-        <button id="winshirt-close-modal" class="ws-close ws-ml-auto">Fermer ✖️</button>
+    <div class="ws-right winshirt-theme-inherit">
+      <div class="ws-tabs-header winshirt-theme-inherit">
+        <button class="ws-tab-button active winshirt-theme-inherit" data-tab="gallery">🖼 Galerie</button>
+        <button class="ws-tab-button winshirt-theme-inherit" data-tab="text">🔤 Texte</button>
+        <button class="ws-tab-button winshirt-theme-inherit" data-tab="ai">🤖 IA</button>
+        <button class="ws-tab-button winshirt-theme-inherit" data-tab="svg">✒️ SVG</button>
+        <button id="ws-reset-visual" class="ws-reset winshirt-theme-inherit">Réinitialiser ↺</button>
+        <button id="winshirt-close-modal" class="ws-close ws-ml-auto winshirt-theme-inherit">Fermer ✖️</button>
       </div>
 
-      <select id="ws-tab-select" class="ws-tab-select">
+      <select id="ws-tab-select" class="ws-tab-select winshirt-theme-inherit">
         <option value="gallery">Galerie</option>
         <option value="text">Texte</option>
         <option value="ai">IA</option>
         <option value="svg">SVG</option>
       </select>
 
-      <button class="ws-accordion-header" data-tab="gallery">🖼 Galerie</button>
+      <button class="ws-accordion-header winshirt-theme-inherit" data-tab="gallery">🖼 Galerie</button>
       <div class="ws-tab-content" id="ws-tab-gallery">
         <p>Choisissez un design dans la galerie.</p>
-        <div class="ws-gallery-cats"></div>
-        <div class="ws-gallery"></div>
-        <button class="ws-upload-btn">Uploader un visuel</button>
-        <input type="file" id="ws-upload-input" accept="image/*" class="hidden" />
+        <div class="ws-gallery-cats winshirt-theme-inherit"></div>
+        <div class="ws-gallery winshirt-theme-inherit"></div>
+        <button class="ws-upload-btn winshirt-theme-inherit">Uploader un visuel</button>
+        <input type="file" id="ws-upload-input" accept="image/*" class="hidden winshirt-theme-inherit" />
       </div>
 
-      <button class="ws-accordion-header" data-tab="text">🔤 Texte</button>
+      <button class="ws-accordion-header winshirt-theme-inherit" data-tab="text">🔤 Texte</button>
       <div class="ws-tab-content hidden" id="ws-tab-text">
-        <input type="text" id="ws-text-content" class="ws-input" placeholder="Votre texte..." />
-        <select id="ws-font-select" class="ws-select">
+        <input type="text" id="ws-text-content" class="ws-input winshirt-theme-inherit" placeholder="Votre texte..." />
+        <select id="ws-font-select" class="ws-select winshirt-theme-inherit">
           <?php
           $fonts = [
             'Arial',
@@ -67,67 +67,67 @@
             </option>
           <?php endforeach; ?>
         </select>
-        <div class="ws-formatting">
-          <button type="button" id="ws-bold-btn">B</button>
-          <button type="button" id="ws-italic-btn">I</button>
-          <button type="button" id="ws-underline-btn">U</button>
-          <input type="color" id="ws-color-picker" value="#000000" />
+        <div class="ws-formatting winshirt-theme-inherit">
+          <button type="button" id="ws-bold-btn" class="winshirt-theme-inherit">B</button>
+          <button type="button" id="ws-italic-btn" class="winshirt-theme-inherit">I</button>
+          <button type="button" id="ws-underline-btn" class="winshirt-theme-inherit">U</button>
+          <input type="color" id="ws-color-picker" class="winshirt-theme-inherit" value="#000000" />
         </div>
-        <label><?php esc_html_e('Taille', 'winshirt'); ?> 
-          <input type="range" id="ws-scale-range" min="0.5" max="2" step="0.1" value="1">
+        <label class="winshirt-theme-inherit"><?php esc_html_e('Taille', 'winshirt'); ?>
+          <input type="range" id="ws-scale-range" class="winshirt-theme-inherit" min="0.5" max="2" step="0.1" value="1">
         </label>
-        <label><?php esc_html_e('Rotation', 'winshirt'); ?> 
-          <input type="range" id="ws-rotate-range" min="0" max="360" step="1" value="0">
+        <label class="winshirt-theme-inherit"><?php esc_html_e('Rotation', 'winshirt'); ?>
+          <input type="range" id="ws-rotate-range" class="winshirt-theme-inherit" min="0" max="360" step="1" value="0">
         </label>
-        <button class="ws-upload-btn" id="ws-add-text">Ajouter</button>
+        <button class="ws-upload-btn winshirt-theme-inherit" id="ws-add-text">Ajouter</button>
       </div>
 
-      <button class="ws-accordion-header" data-tab="ai">🤖 IA</button>
+      <button class="ws-accordion-header winshirt-theme-inherit" data-tab="ai">🤖 IA</button>
       <div class="ws-tab-content hidden" id="ws-tab-ai">
         <p>Générez une image grâce à l’IA (bientôt disponible).</p>
       </div>
 
-      <button class="ws-accordion-header" data-tab="svg">✒️ SVG</button>
+      <button class="ws-accordion-header winshirt-theme-inherit" data-tab="svg">✒️ SVG</button>
       <div class="ws-tab-content hidden" id="ws-tab-svg">
         <p>Bibliothèque d’icônes vectorielles (SVG).</p>
       </div>
 
 
-      <div class="ws-sidebar hidden">
+      <div class="ws-sidebar hidden winshirt-theme-inherit">
         <h3><?php esc_html_e( 'Édition', 'winshirt' ); ?></h3>
-        <label><?php esc_html_e( 'Taille', 'winshirt' ); ?>
-          <input type="range" id="ws-prop-scale" min="0.5" max="2" step="0.1" value="1">
+        <label class="winshirt-theme-inherit"><?php esc_html_e( 'Taille', 'winshirt' ); ?>
+          <input type="range" id="ws-prop-scale" class="winshirt-theme-inherit" min="0.5" max="2" step="0.1" value="1">
         </label>
-        <label><?php esc_html_e( 'Rotation', 'winshirt' ); ?>
-          <input type="range" id="ws-prop-rotate" min="0" max="360" step="1" value="0">
+        <label class="winshirt-theme-inherit"><?php esc_html_e( 'Rotation', 'winshirt' ); ?>
+          <input type="range" id="ws-prop-rotate" class="winshirt-theme-inherit" min="0" max="360" step="1" value="0">
         </label>
-        <label class="ws-color-field">
+        <label class="ws-color-field winshirt-theme-inherit">
           <?php esc_html_e( 'Couleur', 'winshirt' ); ?>
-          <input type="color" id="ws-prop-color" value="#000000">
+          <input type="color" id="ws-prop-color" class="winshirt-theme-inherit" value="#000000">
         </label>
-        <button id="ws-prop-delete" class="ws-delete" type="button">
+        <button id="ws-prop-delete" class="ws-delete winshirt-theme-inherit" type="button">
           <?php esc_html_e( 'Supprimer', 'winshirt' ); ?>
         </button>
       </div>
 
-      <div class="ws-colors"></div>
+      <div class="ws-colors winshirt-theme-inherit"></div>
       <input type="hidden" id="winshirt-custom-data" value="" />
 
-        <div class="ws-actions">
-          <div class="ws-format-buttons">
-            <button class="ws-format-btn" data-format="A3">A3</button>
-            <button class="ws-format-btn" data-format="A4">A4</button>
-            <button class="ws-format-btn" data-format="A5">A5</button>
-            <button class="ws-format-btn" data-format="A6">A6</button>
-            <button class="ws-format-btn" data-format="A7">A7</button>
+        <div class="ws-actions winshirt-theme-inherit">
+          <div class="ws-format-buttons winshirt-theme-inherit">
+            <button class="ws-format-btn winshirt-theme-inherit" data-format="A3">A3</button>
+            <button class="ws-format-btn winshirt-theme-inherit" data-format="A4">A4</button>
+            <button class="ws-format-btn winshirt-theme-inherit" data-format="A5">A5</button>
+            <button class="ws-format-btn winshirt-theme-inherit" data-format="A6">A6</button>
+            <button class="ws-format-btn winshirt-theme-inherit" data-format="A7">A7</button>
             <span id="ws-current-format" class="ws-format-label"></span>
           </div>
-          <div class="ws-toggle">
-            <button id="winshirt-front-btn" class="ws-side-btn active">Recto</button>
-            <button id="winshirt-back-btn" class="ws-side-btn">Verso</button>
+          <div class="ws-toggle winshirt-theme-inherit">
+            <button id="winshirt-front-btn" class="ws-side-btn active winshirt-theme-inherit">Recto</button>
+            <button id="winshirt-back-btn" class="ws-side-btn winshirt-theme-inherit">Verso</button>
           </div>
           <small class="ws-size-note">Taille réelle estimée sur un visuel 1500x1500px – affichage à titre indicatif.</small>
-          <button id="winshirt-validate" class="ws-validate">Valider la personnalisation</button>
+          <button id="winshirt-validate" class="ws-validate winshirt-theme-inherit">Valider la personnalisation</button>
         </div>
 
     </div>


### PR DESCRIPTION
## Summary
- add `winshirt-theme` stylesheet for inheriting theme styles
- tweak lottery and warning spacing
- update lottery card HTML to include theme-inherit class
- expose color overlay without displaying picker
- apply theme-inherit classes across the personalizer modal

## Testing
- `php -l includes/init.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e37c0aa308329ac88693243388c21