### PR TITLE
Move customization button above size options

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -307,7 +307,8 @@ function winshirt_render_customize_button() {
     $ws_gallery = wp_json_encode( $gallery );
     include WINSHIRT_PATH . 'templates/personalizer-modal.php';
 }
-add_action( 'woocommerce_single_product_summary', 'winshirt_render_customize_button', 35 );
+// Place the customization button above the size/variation selection
+add_action( 'woocommerce_before_add_to_cart_form', 'winshirt_render_customize_button', 5 );
 
 function winshirt_render_color_picker() {
     global $product;


### PR DESCRIPTION
## Summary
- adjust hook so "Personaliser ce produit" button appears before size selection

## Testing
- `php -l includes/init.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e85d259cc8329ba550a0f56701955