### PR TITLE
Fix disabled customizer button

### DIFF
--- a/assets/js/winshirt-lottery-enforce.js
+++ b/assets/js/winshirt-lottery-enforce.js
@@ -1,5 +1,6 @@
 jQuery(function($){
-  var $button  = $('.single_add_to_cart_button');
+  // Target only the WooCommerce "Add to cart" button inside the form
+  var $button  = $('form.cart .single_add_to_cart_button');
   var $selects = $('.winshirt-lottery-select');
   var $custom  = $('#winshirt-custom-data');
 


### PR DESCRIPTION
## Summary
- fix selector in lottery script to avoid disabling the customizer button

## Testing
- `php -l` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ee37efe2c8329a2216858a7893edd