### PR TITLE
Apply WooCommerce classes to frontend forms

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -272,7 +272,7 @@ function winshirt_render_customize_button() {
         }
     }
 
-    echo '<button id="winshirt-open-modal" class="button single_add_to_cart_button winshirt-theme-inherit">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button>';
+    echo '<button id="winshirt-open-modal" class="single_add_to_cart_button button alt winshirt-theme-inherit">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button>';
     $default_front = $front_url;
     $default_back  = $back_url;
     $ws_colors     = wp_json_encode( $colors );

--- a/includes/pages/visuels.php
+++ b/includes/pages/visuels.php
@@ -71,7 +71,7 @@ function winshirt_page_designs() {
                 echo '<div class="updated"><p>' . esc_html__('Visuel ajouté.', 'winshirt') . '</p></div>';
             }
         } else {
-            echo '<div class="error"><p>' . esc_html__('Erreur lors de l\'upload.', 'winshirt') . '</p></div>';
+            echo '<div class="woocommerce-error"><p>' . esc_html__('Erreur lors de l\'upload.', 'winshirt') . '</p></div>';
         }
     }
 

--- a/templates/frontend/modal-personnalisation.php
+++ b/templates/frontend/modal-personnalisation.php
@@ -8,28 +8,28 @@
       <li><a href="#winshirt-tab-svg">🖌️ SVG</a></li>
     </ul>
     <div class="winshirt-tab" id="winshirt-tab-galerie">
-      <button class="winshirt-upload button">Uploader un visuel</button>
+      <button class="winshirt-upload button alt">Uploader un visuel</button>
       <input type="file" class="winshirt-upload-input" style="display:none" accept="image/*" />
       <p>Choisissez un design dans la galerie.</p>
     </div>
     <div class="winshirt-tab" id="winshirt-tab-texte">
-      <button class="winshirt-upload button">Uploader un visuel</button>
+      <button class="winshirt-upload button alt">Uploader un visuel</button>
       <input type="file" class="winshirt-upload-input" style="display:none" accept="image/*" />
-      <textarea id="winshirt-text-input" rows="3" style="width:100%;" placeholder="Votre texte..."></textarea>
+      <textarea id="winshirt-text-input" class="input-text" rows="3" style="width:100%;" placeholder="Votre texte..."></textarea>
     </div>
     <div class="winshirt-tab" id="winshirt-tab-ia">
-      <button class="winshirt-upload button">Uploader un visuel</button>
+      <button class="winshirt-upload button alt">Uploader un visuel</button>
       <input type="file" class="winshirt-upload-input" style="display:none" accept="image/*" />
       <p>Générez une image grâce à l'IA (bientôt disponible).</p>
     </div>
     <div class="winshirt-tab" id="winshirt-tab-svg">
-      <button class="winshirt-upload button">Uploader un visuel</button>
+      <button class="winshirt-upload button alt">Uploader un visuel</button>
       <input type="file" class="winshirt-upload-input" style="display:none" accept="image/*" />
       <p>Bibliothèque d'icônes vectorielles.</p>
     </div>
     <div class="winshirt-preview-buttons">
-      <button id="winshirt-front-btn" class="button">Recto</button>
-      <button id="winshirt-back-btn" class="button">Verso</button>
+      <button id="winshirt-front-btn" class="button alt">Recto</button>
+      <button id="winshirt-back-btn" class="button alt">Verso</button>
     </div>
     <div class="winshirt-preview">
       <div id="winshirt-preview-front" style="display:none;position:relative;">

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -27,7 +27,7 @@
         <button id="winshirt-close-modal" class="ws-close ws-ml-auto winshirt-theme-inherit">Fermer ✖️</button>
       </div>
 
-      <select id="ws-tab-select" class="ws-tab-select winshirt-theme-inherit">
+      <select id="ws-tab-select" class="ws-tab-select select winshirt-theme-inherit">
         <option value="gallery">Galerie</option>
         <option value="text">Texte</option>
         <option value="ai">IA</option>
@@ -45,8 +45,8 @@
 
       <button class="ws-accordion-header winshirt-theme-inherit" data-tab="text">🔤 Texte</button>
       <div class="ws-tab-content hidden" id="ws-tab-text">
-        <input type="text" id="ws-text-content" class="ws-input winshirt-theme-inherit" placeholder="Votre texte..." />
-        <select id="ws-font-select" class="ws-select winshirt-theme-inherit">
+        <input type="text" id="ws-text-content" class="ws-input input-text winshirt-theme-inherit" placeholder="Votre texte..." />
+        <select id="ws-font-select" class="ws-select select winshirt-theme-inherit">
           <?php
           $fonts = [
             'Arial',


### PR DESCRIPTION
## Summary
- style the "Personnaliser ce produit" button like WooCommerce
- adjust personalizer inputs to use WooCommerce classes
- update old modal markup
- show upload error using `woocommerce-error`

## Testing
- `php -l includes/init.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee7c9b6e08329a6d860c9680b4f16