### PR TITLE
Improve lottery selector UI

### DIFF
--- a/assets/css/winshirt-theme.css
+++ b/assets/css/winshirt-theme.css
@@ -12,3 +12,23 @@
 }
 
 
+.winshirt-lottery-label {
+  font-weight: 700;
+  display: block;
+}
+
+.winshirt-lottery-tooltip {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  background: rgba(40,70,120,0.95);
+  color: #fff;
+  padding: 4px 12px;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  box-shadow: 0 2px 14px rgba(20,40,100,0.18);
+  white-space: nowrap;
+  display: none;
+  z-index: 9;
+}

--- a/assets/js/winshirt-lottery-enforce.js
+++ b/assets/js/winshirt-lottery-enforce.js
@@ -1,6 +1,6 @@
 jQuery(function($){
-  // Target only the WooCommerce "Add to cart" button inside the form
-  var $button  = $('form.cart .single_add_to_cart_button');
+  var $form    = $('form.cart');
+  var $button  = $form.find('.single_add_to_cart_button');
   var $selects = $('.winshirt-lottery-select');
   var $custom  = $('#winshirt-custom-data');
 
@@ -14,8 +14,9 @@ jQuery(function($){
     return;
   }
 
-  var $warning = $('<p class="winshirt-lottery-warning winshirt-theme-inherit"></p>');
-  $warning.insertAfter($button.first());
+  var $tooltip = $('<div class="winshirt-lottery-tooltip winshirt-theme-inherit"></div>').hide();
+  $button.after($tooltip);
+  var timeout = null;
 
   function anySelected(){
     var ok = false;
@@ -30,28 +31,18 @@ jQuery(function($){
     return !requiresCustom || ($custom.val() && $custom.val().length > 2);
   }
 
-  function updateState(){
+  $form.on('submit', function(e){
     var okLottery = !requiresLottery || anySelected();
     var okCustom  = customValid();
-
-    if(okLottery && okCustom){
-      $button.prop('disabled', false);
-      $warning.hide();
-    }else{
-      $button.prop('disabled', true);
+    if(!(okLottery && okCustom)){
+      e.preventDefault();
       var parts = [];
       if(requiresLottery && !okLottery){ parts.push('une loterie'); }
       if(requiresCustom && !okCustom){ parts.push('votre personnalisation'); }
-      $warning.text('Veuillez sélectionner '+parts.join(' et ')+' avant d\u2019ajouter au panier.');
-      $warning.show();
+      $tooltip.text('Veuillez sélectionner '+parts.join(' et ')+' avant d\u2019ajouter au panier.')
+             .fadeIn(120);
+      clearTimeout(timeout);
+      timeout = setTimeout(function(){ $tooltip.fadeOut(200); }, 4000);
     }
-  }
-
-  $selects.on('change', updateState);
-  $custom.on('change', updateState);
-  $('#winshirt-validate').on('click', function(){
-    setTimeout(updateState, 100);
   });
-
-  updateState();
 });

--- a/includes/init.php
+++ b/includes/init.php
@@ -307,8 +307,8 @@ function winshirt_render_customize_button() {
     $ws_gallery = wp_json_encode( $gallery );
     include WINSHIRT_PATH . 'templates/personalizer-modal.php';
 }
-// Place the customization button above the size/variation selection
-add_action( 'woocommerce_before_add_to_cart_form', 'winshirt_render_customize_button', 5 );
+// Place the customization button inside the cart form before the "Add to cart" button
+add_action( 'woocommerce_before_add_to_cart_button', 'winshirt_render_customize_button', 5 );
 
 function winshirt_render_color_picker() {
     global $product;
@@ -390,7 +390,7 @@ function winshirt_render_lottery_selector() {
     echo '<div class="winshirt-lottery-selects winshirt-theme-inherit">';
     for ( $i = 1; $i <= $tickets; $i++ ) {
         echo '<div class="form-row form-row-wide winshirt-lottery-select winshirt-theme-inherit">';
-        echo '<label class="winshirt-theme-inherit" for="winshirt-lottery-select-' . $i . '">' . esc_html__( 'Ticket n°', 'winshirt' ) . $i . '</label> ';
+        echo '<label class="winshirt-theme-inherit winshirt-lottery-label" for="winshirt-lottery-select-' . $i . '"><strong>' . esc_html__( 'Ticket n°', 'winshirt' ) . $i . ':</strong></label><br />';
         echo '<select id="winshirt-lottery-select-' . $i . '" class="winshirt-lottery-select select winshirt-theme-inherit" name="winshirt_lotteries[]">';
         echo '<option value="">' . esc_html__( '-- Sélectionner --', 'winshirt' ) . '</option>';
         foreach ( $lotteries as $lottery ) {


### PR DESCRIPTION
## Summary
- show lottery requirement message as tooltip on add-to-cart when nothing selected
- bold Ticket labels with a colon and line break
- style tooltip and label with new CSS classes
- move "Personnaliser" button into add-to-cart area so it inherits theme styling

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6860e30c8e908329b48cb1b2ba2b3d10