### PR TITLE
Add AI settings section

### DIFF
--- a/assets/js/winshirt-admin.js
+++ b/assets/js/winshirt-admin.js
@@ -12,5 +12,31 @@
       var page = root.getAttribute('data-page') || '';
       render(createElement(App, {page: page}), root);
     }
+
+    var testBtn = document.getElementById('winshirt-test-ia-key');
+    if(testBtn){
+      testBtn.addEventListener('click', function(e){
+        e.preventDefault();
+        var field = document.getElementById('winshirt-ia-api-key');
+        var key = field ? field.value : '';
+        testBtn.disabled = true;
+        testBtn.textContent = 'Test en cours...';
+        window.fetch(ajaxurl, {
+          method: 'POST',
+          headers: {'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'},
+          body: new URLSearchParams({
+            action: 'winshirt_test_ia_key',
+            key: key
+          })
+        }).then(function(r){return r.json();}).then(function(res){
+          alert(res.data && res.data.message ? res.data.message : (res.success ? 'Succès' : 'Erreur'));
+        }).catch(function(){
+          alert('Erreur de requête');
+        }).finally(function(){
+          testBtn.disabled = false;
+          testBtn.textContent = 'Tester la clé';
+        });
+      });
+    }
   });
 })(window.wp || {element:{createElement:function(){},render:function(){}}});

--- a/templates/admin/partials/configuration-form.php
+++ b/templates/admin/partials/configuration-form.php
@@ -17,5 +17,32 @@
             <td><input name="winshirt_ftp_pass" id="winshirt-ftp-pass" type="password" value="<?php echo esc_attr(get_option('winshirt_ftp_pass')); ?>" class="regular-text" /></td>
         </tr>
     </table>
+
+    <h2>Paramètres IA</h2>
+    <table class="form-table">
+        <tr>
+            <th scope="row"><label for="winshirt-ia-api-key">Clé API IA</label></th>
+            <td>
+                <input name="winshirt_ia_api_key" id="winshirt-ia-api-key" type="password" value="<?php echo esc_attr(get_option('winshirt_ia_api_key')); ?>" class="regular-text" />
+                <button id="winshirt-test-ia-key" class="button">Tester la clé</button>
+            </td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="winshirt-ia-model">Modèle IA</label></th>
+            <td><input name="winshirt_ia_model" id="winshirt-ia-model" type="text" value="<?php echo esc_attr(get_option('winshirt_ia_model', 'dall-e-3')); ?>" class="regular-text" /></td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="winshirt-ia-output-format">Format de sortie</label></th>
+            <td><input name="winshirt_ia_output_format" id="winshirt-ia-output-format" type="text" value="<?php echo esc_attr(get_option('winshirt_ia_output_format', '1024x1024')); ?>" class="regular-text" /></td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="winshirt-ia-generation-limit">Limite de génération</label></th>
+            <td><input name="winshirt_ia_generation_limit" id="winshirt-ia-generation-limit" type="number" value="<?php echo esc_attr(get_option('winshirt_ia_generation_limit', '5')); ?>" class="small-text" /></td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="winshirt-ia-image-folder">Dossier de stockage</label></th>
+            <td><input name="winshirt_ia_image_folder" id="winshirt-ia-image-folder" type="text" value="<?php echo esc_attr(get_option('winshirt_ia_image_folder', '/wp-content/uploads/winshirt/ia/')); ?>" class="regular-text" /></td>
+        </tr>
+    </table>
     <?php submit_button(); ?>
 </form>


### PR DESCRIPTION
## Summary
- manage new AI settings options
- provide admin UI for editing AI parameters
- allow testing API key via Ajax

## Testing
- `php -l includes/init.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860e8af4c188329857ba566d6208244