### PR TITLE
Fix print zone layout in modal

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -206,10 +206,10 @@
   justify-content: center;
 }
 .mockup-fixed {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
+  position: relative;
+  left: auto;
+  top: auto;
+  transform: none;
   margin-top: 0;
 }
 .ws-preview-img {
@@ -314,10 +314,8 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 8px;
+  gap: 10px;
   margin-top: 20px;
-  position: relative;
-  bottom: 0;
 }
 .ws-zone-btn {
   background: rgba(255,255,255,0.1);
@@ -401,24 +399,22 @@
   pointer-events: none;
   overflow: hidden !important;
   display: none;
-  background: none;
+  background: transparent;
+  transition: all 0.2s ease;
 }
 .ws-print-zone.active {
   border-color: #fff;
 }
 .ws-zone-label {
   position: absolute;
-  top: 2px;
-  left: 2px;
-  background: rgba(0,0,0,0.6);
+  top: -20px;
+  left: 0;
+  font-size: 12px;
+  background: rgba(0,0,0,0.5);
   color: #fff;
-  font-size: 11px;
-  padding: 0 4px;
-  border-radius: 3px;
+  padding: 2px 6px;
+  border-radius: 4px;
   pointer-events: none;
-  display: none;
-}
-.ws-print-zone.active .ws-zone-label {
   display: block;
 }
 
@@ -646,10 +642,11 @@
   overflow: hidden !important;
   position: absolute !important;
   border: 2px dashed rgba(255,255,255,0.6);
-  background: none;
+  background: transparent;
   z-index: 10;
   cursor: move;
   box-sizing: border-box;
+  transition: all 0.2s ease;
 }
 
 /* Poign\xC3\xA9es de resize */

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -281,15 +281,19 @@ jQuery(function($){
     saveState();
   });
 
+  $zonesWrap.empty();
+  $zoneButtons.empty();
   zones.forEach(function(z, idx){
     var $z = $('<div class="ws-print-zone" />')
       .attr('data-side', z.side || 'front')
       .attr('data-index', idx)
-      .css({top:z.top+'%',left:z.left+'%',width:z.width+'%',height:z.height+'%'});
-    var $lab = $('<span class="ws-zone-label" />').text(z.name || '');
+      .css({top:z.top+'%', left:z.left+'%', width:z.width+'%', height:z.height+'%'});
+    var $lab = $('<div class="ws-zone-label" />').text(z.name || '');
     $z.append($lab);
     $zonesWrap.append($z);
-    var $btn = $('<button class="ws-zone-btn" />').text(z.name || ('Zone '+(idx+1))).attr('data-index', idx);
+    var $btn = $('<button class="ws-zone-btn" />')
+      .text(z.name || ('Zone '+(idx+1)))
+      .attr('data-index', idx);
     $zoneButtons.append($btn);
   });
   $zoneButtons.on('click', '.ws-zone-btn', function(){


### PR DESCRIPTION
## Summary
- tweak mockup container so image remains centered
- fix print-zone styling and labels
- remove duplication when building zone list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68610ddea58083299effdaaf3b4ea113