### PR TITLE
Improve mobile customization modal layout

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -724,3 +724,45 @@
 .ws-ai-del { position:absolute; top:2px; right:2px; background:rgba(0,0,0,0.6); color:#fff; border-radius:3px; padding:2px; font-size:12px; display:none; cursor:pointer; }
 .ws-ai-thumb-wrap:hover .ws-ai-del { display:block; }
 .ws-ai-label { position:absolute; bottom:2px; left:2px; background:rgba(0,0,0,0.6); color:#fff; font-size:10px; padding:2px 3px; border-radius:3px; }
+
+/* --- Mobile refonte --- */
+.ws-context-actions {
+  display:flex;
+  flex-wrap:wrap;
+  gap:.5rem;
+  justify-content:center;
+  margin-top:.5rem;
+}
+.ws-format-select {
+  background:rgba(255,255,255,0.1);
+  border:1px solid rgba(255,255,255,0.2);
+  color:#fff;
+  padding:.25rem .5rem;
+  border-radius:.25rem;
+}
+.ws-tools {
+  position:fixed;
+  left:0; right:0; bottom:0;
+  display:flex;
+  justify-content:space-around;
+  gap:.25rem;
+  padding:.5rem;
+  background:rgba(0,0,0,0.7);
+  backdrop-filter:blur(8px);
+  z-index:10001;
+}
+.ws-tool-btn {
+  flex:1;
+  padding:.5rem 0;
+  background:rgba(255,255,255,0.1);
+  border:1px solid rgba(255,255,255,0.2);
+  border-radius:.5rem;
+  color:#fff;
+  font-size:1.25rem;
+}
+.ws-tool-btn:hover {
+  background:rgba(255,255,255,0.3);
+}
+@media(min-width:769px){
+  .ws-tools { display:none; }
+}

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -17,9 +17,7 @@ jQuery(function($){
   var colors = $modal.data('colors') || [];
   var zones  = $modal.data('zones') || [];
   var $colorsWrap = $modal.find('.ws-colors');
-  var $formatWrap = $modal.find('.ws-format-buttons');
-  var $formatBtns = $formatWrap.find('.ws-format-btn');
-  var $formatLabel = $('#ws-current-format');
+  var $formatSelect = $('#ws-format-select');
   var $zonesWrap = $('#ws-print-zones');
   var $zoneButtons = $('#ws-zone-buttons');
   var $left = $modal.find('.ws-left');
@@ -346,21 +344,11 @@ jQuery(function($){
       var d = Math.abs(ratio - formatHeights[f]);
       if(d < closest.diff){ closest = {fmt:f, diff:d}; }
     });
-    $formatBtns.removeClass('active');
-    $formatBtns.filter('[data-format="'+closest.fmt+'"]').addClass('active');
-    if($formatLabel.length){
-      if(closest.diff < 0.02){
-        $formatLabel.text('Format actuel : '+closest.fmt);
-      } else {
-        $formatLabel.text('Personnalisé (≈ '+closest.fmt+')');
-      }
-    }
+    if($formatSelect.length){ $formatSelect.val(closest.fmt); }
   }
 
   function updateFormatUI(fmt){
-    $formatBtns.removeClass('active');
-    $formatBtns.filter('[data-format="'+fmt+'"]').addClass('active');
-    if($formatLabel.length){ $formatLabel.text('Format actuel : '+fmt); }
+    if($formatSelect.length){ $formatSelect.val(fmt); }
   }
 
   function applyFormat($it, fmt){
@@ -490,6 +478,12 @@ function openModal(){
   $('.ws-accordion-header').on('click', function(){
     openTab($(this).data('tab'));
   });
+  $('.ws-tool-btn[data-tab]').on('click', function(){
+    openTab($(this).data('tab'));
+  });
+  $('#ws-upload-tool').on('click', function(){
+    $('#ws-upload-trigger').trigger('click');
+  });
   $tabSelect.on('change', function(){
     openTab($(this).val());
   });
@@ -547,12 +541,11 @@ function openModal(){
       saveState();
     }
   });
-
-  $formatWrap.on('click', '.ws-format-btn', function(){
+  $formatSelect.on('change', function(){
     if(!activeItem) return;
-    var fmt = $(this).data('format');
-    applyFormat(activeItem, fmt);
+    applyFormat(activeItem, $(this).val());
   });
+
 
   function addItem(type, content){
     // Supprime l'image existante si besoin
@@ -717,8 +710,7 @@ function openModal(){
       $sidebar.addClass('show');
     } else {
       $sidebar.removeClass('show');
-      $formatBtns.removeClass('active');
-      $formatLabel.text('');
+      if($formatSelect.length){ $formatSelect.val('A3'); }
       $removeBgBtn.addClass('hidden');
     }
   }

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -16,6 +16,21 @@
         <div id="ws-print-zones"></div>
       </div>
       <div id="ws-zone-buttons" class="ws-zone-buttons winshirt-theme-inherit"></div>
+      <div class="ws-context-actions winshirt-theme-inherit">
+        <button id="ws-remove-bg" class="ws-delete winshirt-theme-inherit hidden" type="button">🧼</button>
+        <select id="ws-format-select" class="ws-format-select winshirt-theme-inherit">
+          <option value="A3">A3</option>
+          <option value="A4">A4</option>
+          <option value="A5">A5</option>
+          <option value="A6">A6</option>
+          <option value="A7">A7</option>
+        </select>
+        <button id="ws-prop-delete" class="ws-delete winshirt-theme-inherit" type="button">🗑</button>
+        <div class="ws-toggle winshirt-theme-inherit">
+          <button id="winshirt-front-btn" class="ws-side-btn active winshirt-theme-inherit">Recto</button>
+          <button id="winshirt-back-btn" class="ws-side-btn winshirt-theme-inherit">Verso</button>
+        </div>
+      </div>
     </div>
 
     <div class="ws-right winshirt-theme-inherit">
@@ -111,35 +126,24 @@
           <?php esc_html_e( 'Couleur', 'winshirt' ); ?>
           <input type="color" id="ws-prop-color" class="winshirt-theme-inherit" value="#000000">
         </label>
-        <button id="ws-remove-bg" class="ws-delete winshirt-theme-inherit hidden" type="button">🧼
-          <?php esc_html_e( 'Supprimer le fond', 'winshirt' ); ?>
-        </button>
-        <button id="ws-prop-delete" class="ws-delete winshirt-theme-inherit" type="button">
-          <?php esc_html_e( 'Supprimer', 'winshirt' ); ?>
-        </button>
       </div>
 
       <div class="ws-colors winshirt-theme-inherit"></div>
       <input type="hidden" id="winshirt-custom-data" value="" />
 
         <div class="ws-actions winshirt-theme-inherit">
-          <div class="ws-format-buttons winshirt-theme-inherit">
-            <button class="ws-format-btn winshirt-theme-inherit" data-format="A3">A3</button>
-            <button class="ws-format-btn winshirt-theme-inherit" data-format="A4">A4</button>
-            <button class="ws-format-btn winshirt-theme-inherit" data-format="A5">A5</button>
-            <button class="ws-format-btn winshirt-theme-inherit" data-format="A6">A6</button>
-            <button class="ws-format-btn winshirt-theme-inherit" data-format="A7">A7</button>
-            <span id="ws-current-format" class="ws-format-label"></span>
-          </div>
-          <div class="ws-toggle winshirt-theme-inherit">
-            <button id="winshirt-front-btn" class="ws-side-btn active winshirt-theme-inherit">Recto</button>
-            <button id="winshirt-back-btn" class="ws-side-btn winshirt-theme-inherit">Verso</button>
-          </div>
           <small class="ws-size-note">Taille réelle estimée sur un visuel 1500x1500px – affichage à titre indicatif.</small>
           <button id="winshirt-validate" class="ws-validate winshirt-theme-inherit">Valider la personnalisation</button>
         </div>
 
     </div>
-    <div id="ws-debug" class="ws-debug"></div>
+  <div id="ws-debug" class="ws-debug"></div>
+  <div class="ws-tools winshirt-theme-inherit">
+    <button class="ws-tool-btn" data-tab="gallery">📷</button>
+    <button class="ws-tool-btn" id="ws-upload-tool">⬆</button>
+    <button class="ws-tool-btn" data-tab="ai">🤖</button>
+    <button class="ws-tool-btn" data-tab="text">✏</button>
+    <button class="ws-tool-btn" data-tab="svg">📄</button>
   </div>
+</div>
 </div>


### PR DESCRIPTION
## Summary
- refactor `personalizer-modal.php` markup to centralize context actions
- add bottom toolbar with quick tabs and upload button
- replace format buttons by a single select
- style new components in `winshirt-modal.css`
- update JS to handle new toolbar and format selector

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611fad69d08329853447612c6d3e98