### PR TITLE
Improve mobile personalizer layout

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -766,3 +766,21 @@
 @media(min-width:769px){
   .ws-tools { display:none; }
 }
+
+/* Responsive mobile refinements */
+.winshirt-personnalisation-mobile {
+  display:flex;
+  flex-direction:column;
+  gap:.5rem;
+}
+.winshirt-personnalisation-mobile button {
+  min-width:40px;
+  min-height:40px;
+  border-radius:.5rem;
+  box-shadow:0 2px 4px rgba(0,0,0,0.2);
+  backdrop-filter:blur(4px);
+}
+#btn-valider-personnalisation {
+  position:sticky;
+  bottom:0;
+}

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -87,10 +87,10 @@ jQuery(function($){
 
   function checkMobile(){
     if(window.innerWidth <= 768){
-      $modal.addClass('ws-mobile');
+      $modal.addClass('ws-mobile winshirt-personnalisation-mobile');
       if($zoneButtons.parent()[0] !== $right[0]){ $zoneButtons.appendTo($right); }
     } else {
-      $modal.removeClass('ws-mobile');
+      $modal.removeClass('ws-mobile winshirt-personnalisation-mobile');
       $modal.find('.ws-right').removeClass('show');
       if($zoneButtons.parent()[0] !== $left[0]){ $zoneButtons.appendTo($left); }
     }
@@ -455,7 +455,8 @@ function openModal(){
     }, 300);
   }
 
-  $('#winshirt-open-modal').on('click', function(e){ e.preventDefault(); openModal(); });
+  // Ouvre la modale depuis le bouton de personnalisation
+  $('#btn-personnaliser').on('click', function(e){ e.preventDefault(); openModal(); });
   $('#winshirt-close-modal').on('click', closeModal);
   $('#ws-reset-visual').on('click', function(){
     $canvas.children('.ws-item[data-type="image"]').remove();
@@ -820,7 +821,8 @@ function openModal(){
   $('#winshirt-front-btn').on('click', function(){ switchSide('front'); });
   $('#winshirt-back-btn').on('click', function(){ switchSide('back'); });
 
-  $('#winshirt-validate').on('click', function(){
+  // Validation finale : enregistre puis ferme la modale
+  $('#btn-valider-personnalisation').on('click', function(){
     var items = [];
     $canvas.children('.ws-item').each(function(){
       var $it = $(this);

--- a/includes/init.php
+++ b/includes/init.php
@@ -281,7 +281,8 @@ function winshirt_render_customize_button() {
         }
     }
 
-    echo '<button id="winshirt-open-modal" class="single_add_to_cart_button button alt winshirt-theme-inherit">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button>';
+    // Bouton d\xE9clenchant la personnalisation sur la fiche produit
+    echo '<button id="btn-personnaliser" class="single_add_to_cart_button button alt winshirt-theme-inherit btn-orange">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button>';
     $default_front = $front_url;
     $default_back  = $back_url;
     $ws_colors     = wp_json_encode( $colors );
@@ -316,8 +317,8 @@ function winshirt_render_customize_button() {
     $ws_gallery = wp_json_encode( $gallery );
     include WINSHIRT_PATH . 'templates/personalizer-modal.php';
 }
-// Place the customization button inside the cart form before the "Add to cart" button
-add_action( 'woocommerce_before_add_to_cart_button', 'winshirt_render_customize_button', 5 );
+// Affiche le bouton juste sous le prix, avant les billets de loterie
+add_action( 'woocommerce_single_product_summary', 'winshirt_render_customize_button', 15 );
 
 function winshirt_render_color_picker() {
     global $product;

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -133,7 +133,7 @@
 
         <div class="ws-actions winshirt-theme-inherit">
           <small class="ws-size-note">Taille réelle estimée sur un visuel 1500x1500px – affichage à titre indicatif.</small>
-          <button id="winshirt-validate" class="ws-validate winshirt-theme-inherit">Valider la personnalisation</button>
+          <button id="btn-valider-personnalisation" class="ws-validate winshirt-theme-inherit">Valider la personnalisation</button>
         </div>
 
     </div>


### PR DESCRIPTION
## Summary
- move customize button below price and give it `btn-personnaliser` id
- show sticky validation button with id `btn-valider-personnalisation`
- tweak JS to open modal from the new button and update validation handler
- add responsive mobile class `winshirt-personnalisation-mobile` and styles

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68612bfb3b0c832983c56a003bb9c11a