### PR TITLE
Fix modal mockup display and button layout

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -315,7 +315,12 @@
   flex-wrap: wrap;
   justify-content: center;
   gap: 10px;
-  margin-top: 20px;
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 0;
+  z-index: 5;
 }
 .ws-zone-btn {
   background: rgba(255,255,255,0.1);
@@ -419,7 +424,7 @@
 }
 
 @media(max-width:768px){
-  .ws-zone-buttons { justify-content:flex-start; }
+  .ws-zone-buttons { justify-content:center; }
 }
 #ws-print-zones {
   position: absolute;

--- a/assets/css/winshirt-theme.css
+++ b/assets/css/winshirt-theme.css
@@ -32,3 +32,7 @@
   display: none;
   z-index: 9;
 }
+
+.winshirt-personnaliser-btn {
+  margin-top: 15px;
+}

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -88,11 +88,12 @@ jQuery(function($){
   function checkMobile(){
     if(window.innerWidth <= 768){
       $modal.addClass('ws-mobile winshirt-personnalisation-mobile');
-      if($zoneButtons.parent()[0] !== $right[0]){ $zoneButtons.appendTo($right); }
     } else {
       $modal.removeClass('ws-mobile winshirt-personnalisation-mobile');
       $modal.find('.ws-right').removeClass('show');
-      if($zoneButtons.parent()[0] !== $left[0]){ $zoneButtons.appendTo($left); }
+    }
+    if($zoneButtons.parent()[0] !== $modal.find('.ws-preview')[0]){
+      $zoneButtons.appendTo($modal.find('.ws-preview'));
     }
   }
 

--- a/includes/init.php
+++ b/includes/init.php
@@ -245,8 +245,11 @@ function winshirt_render_customize_button() {
         return;
     }
 
-    $front_url  = $front_id ? get_the_post_thumbnail_url( $front_id, 'full' ) : '';
-    $back_url   = $back_id ? get_the_post_thumbnail_url( $back_id, 'full' ) : '';
+    $front_img_id = $front_id ? get_post_meta( $front_id, '_winshirt_front_image', true ) : 0;
+    $back_img_id  = $back_id ? get_post_meta( $back_id, '_winshirt_back_image', true ) : 0;
+
+    $front_url  = $front_img_id ? wp_get_attachment_image_url( $front_img_id, 'full' ) : '';
+    $back_url   = $back_img_id ? wp_get_attachment_image_url( $back_img_id, 'full' ) : '';
 
     // Retrieve available colors from the default mockup
     $colors_meta = $front_id ? get_post_meta( $front_id, '_winshirt_colors', true ) : [];
@@ -282,7 +285,7 @@ function winshirt_render_customize_button() {
     }
 
     // Bouton d\xE9clenchant la personnalisation sur la fiche produit
-    echo '<button id="btn-personnaliser" class="single_add_to_cart_button button alt winshirt-theme-inherit btn-orange">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button>';
+    echo '<div class="winshirt-personnaliser-btn"><button id="btn-personnaliser" class="button alt winshirt-theme-inherit btn-orange">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button></div>';
     $default_front = $front_url;
     $default_back  = $back_url;
     $ws_colors     = wp_json_encode( $colors );

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -14,8 +14,8 @@
         <div class="ws-color-overlay winshirt-theme-inherit"></div>
         <div id="ws-canvas" class="ws-canvas"></div>
         <div id="ws-print-zones"></div>
+        <div id="ws-zone-buttons" class="ws-zone-buttons winshirt-theme-inherit"></div>
       </div>
-      <div id="ws-zone-buttons" class="ws-zone-buttons winshirt-theme-inherit"></div>
       <div class="ws-context-actions winshirt-theme-inherit">
         <button id="ws-remove-bg" class="ws-remove-bg winshirt-theme-inherit hidden" type="button" title="Supprimer le fond">🧼 Supprimer le fond</button>
         <button id="ws-prop-delete" class="ws-delete winshirt-theme-inherit" type="button" title="Supprimer l'élément">🗑️ Supprimer</button>


### PR DESCRIPTION
## Summary
- show correct mockup images using meta fields
- reposition customize button under price
- place print zone buttons inside the preview
- keep zone buttons centered on mobile
- style spacing for customize button

## Testing
- `node --check assets/js/winshirt-modal.js`


------
https://chatgpt.com/codex/tasks/task_e_68618ffc84f083298e9b10ccf6f207f9