### PR TITLE
Align personnaliser button with theme styling

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -285,7 +285,8 @@ function winshirt_render_customize_button() {
     }
 
     // Bouton d\xE9clenchant la personnalisation sur la fiche produit
-    echo '<div class="winshirt-personnaliser-btn"><button id="btn-personnaliser" class="button alt winshirt-theme-inherit btn-orange">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button></div>';
+    // Utilise les mêmes classes que le bouton "Ajouter au panier" pour hériter du style du thème
+    echo '<div class="winshirt-personnaliser-btn"><button id="btn-personnaliser" class="single_add_to_cart_button button alt">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button></div>';
     $default_front = $front_url;
     $default_back  = $back_url;
     $ws_colors     = wp_json_encode( $colors );


### PR DESCRIPTION
## Summary
- use WooCommerce `single_add_to_cart_button` classes so the "Personnaliser" button matches the theme's cart button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686193f7c49c83299b533109ad2bb117