### PR TITLE
Add production image capture and analytics

### DIFF
--- a/assets/js/winshirt-lottery-enforce.js
+++ b/assets/js/winshirt-lottery-enforce.js
@@ -3,6 +3,7 @@ jQuery(function($){
   var $button  = $form.find('.single_add_to_cart_button');
   var $selects = $('.winshirt-lottery-select');
   var $custom  = $('#winshirt-custom-data');
+  var productId = parseInt($form.find('input[name="add-to-cart"]').val()||0,10);
 
   if(!$button.length){
     return;
@@ -43,6 +44,8 @@ jQuery(function($){
              .fadeIn(120);
       clearTimeout(timeout);
       timeout = setTimeout(function(){ $tooltip.fadeOut(200); }, 4000);
+    } else {
+      if(window.dataLayer){ dataLayer.push({event:'add_to_cart', product_id:productId, customization:$custom.val()}); }
     }
   });
 });

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -1,0 +1,104 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * Handle upload of production image captured client side.
+ */
+function winshirt_rest_upload_production_image( WP_REST_Request $request ) {
+    if ( ! is_user_logged_in() ) {
+        return new WP_REST_Response( [ 'message' => 'forbidden' ], 403 );
+    }
+    $nonce = $request->get_header( 'X-WP-Nonce' );
+    if ( ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
+        return new WP_REST_Response( [ 'message' => 'invalid_nonce' ], 403 );
+    }
+
+    $file = $request->get_file_params()['image'] ?? null;
+    if ( ! $file || empty( $file['tmp_name'] ) ) {
+        return new WP_REST_Response( [ 'message' => 'missing_file' ], 400 );
+    }
+
+    $ext = strtolower( pathinfo( $file['name'], PATHINFO_EXTENSION ) );
+    if ( ! in_array( $ext, [ 'png', 'jpg', 'jpeg' ], true ) ) {
+        return new WP_REST_Response( [ 'message' => 'invalid_type' ], 400 );
+    }
+
+    $upload = wp_upload_dir();
+    $dir    = trailingslashit( $upload['basedir'] ) . 'winshirt-productions/';
+    if ( ! file_exists( $dir ) ) {
+        wp_mkdir_p( $dir );
+    }
+
+    $filename = 'prod_tmp_' . time() . '_' . wp_generate_password( 6, false ) . '.' . $ext;
+    $path     = $dir . $filename;
+
+    if ( ! move_uploaded_file( $file['tmp_name'], $path ) ) {
+        return new WP_REST_Response( [ 'message' => 'upload_failed' ], 500 );
+    }
+
+    $url = trailingslashit( $upload['baseurl'] ) . 'winshirt-productions/' . $filename;
+    return new WP_REST_Response( [ 'url' => $url ], 200 );
+}
+
+/**
+ * Upload temporary preview mockup and return URLs of HD and low resolution images.
+ */
+function winshirt_rest_upload_mockup( WP_REST_Request $request ) {
+    if ( ! is_user_logged_in() ) {
+        return new WP_REST_Response( [ 'message' => 'forbidden' ], 403 );
+    }
+    $nonce = $request->get_header( 'X-WP-Nonce' );
+    if ( ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
+        return new WP_REST_Response( [ 'message' => 'invalid_nonce' ], 403 );
+    }
+
+    $file = $request->get_file_params()['image'] ?? null;
+    if ( ! $file || empty( $file['tmp_name'] ) ) {
+        return new WP_REST_Response( [ 'message' => 'missing_file' ], 400 );
+    }
+
+    $ext = strtolower( pathinfo( $file['name'], PATHINFO_EXTENSION ) );
+    if ( ! in_array( $ext, [ 'png', 'jpg', 'jpeg' ], true ) ) {
+        return new WP_REST_Response( [ 'message' => 'invalid_type' ], 400 );
+    }
+
+    $upload = wp_upload_dir();
+    $dir    = trailingslashit( $upload['basedir'] ) . 'winshirt-mockups/';
+    if ( ! file_exists( $dir ) ) {
+        wp_mkdir_p( $dir );
+    }
+
+    $filename = 'mockup_' . time() . '_' . wp_generate_password( 6, false ) . '.' . $ext;
+    $path     = $dir . $filename;
+
+    if ( ! move_uploaded_file( $file['tmp_name'], $path ) ) {
+        return new WP_REST_Response( [ 'message' => 'upload_failed' ], 500 );
+    }
+
+    $thumb = $dir . 'thumb_' . $filename;
+    $editor = wp_get_image_editor( $path );
+    if ( ! is_wp_error( $editor ) ) {
+        $editor->resize( 400, 0, false );
+        $editor->save( $thumb );
+    }
+
+    $baseurl = trailingslashit( $upload['baseurl'] ) . 'winshirt-mockups/';
+    return new WP_REST_Response( [
+        'url'   => $baseurl . $filename,
+        'thumb' => $baseurl . 'thumb_' . $filename,
+    ], 200 );
+}
+
+add_action( 'rest_api_init', function() {
+    register_rest_route( 'winshirt/v1', '/upload-production-image', [
+        'methods'             => WP_REST_Server::CREATABLE,
+        'callback'            => 'winshirt_rest_upload_production_image',
+        'permission_callback' => function(){ return is_user_logged_in(); },
+    ] );
+
+    register_rest_route( 'winshirt/v1', '/upload-mockup', [
+        'methods'             => WP_REST_Server::CREATABLE,
+        'callback'            => 'winshirt_rest_upload_mockup',
+        'permission_callback' => function(){ return is_user_logged_in(); },
+    ] );
+});

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -131,6 +131,7 @@
 
       <div class="ws-colors winshirt-theme-inherit"></div>
       <input type="hidden" id="winshirt-custom-data" value="" />
+      <input type="hidden" id="winshirt-production-image" value="" />
 
         <div class="ws-actions winshirt-theme-inherit">
           <small class="ws-size-note">Taille réelle estimée sur un visuel 1500x1500px – affichage à titre indicatif.</small>

--- a/winshirt.php
+++ b/winshirt.php
@@ -19,6 +19,7 @@ require_once WINSHIRT_PATH . 'includes/pages/loteries.php';
 require_once WINSHIRT_PATH . 'includes/pages/commandes.php';
 require_once WINSHIRT_PATH . 'includes/pages/configuration.php';
 require_once WINSHIRT_PATH . 'winshirt_ia_generate.php';
+require_once WINSHIRT_PATH . 'includes/rest.php';
 
 // Register uninstall hook
 register_uninstall_hook(__FILE__, 'winshirt_plugin_uninstall');


### PR DESCRIPTION
## Summary
- enable html2canvas and REST uploads
- capture customization mockups and production images
- store images in order item meta
- add AI generation limits and storage
- push Google Analytics DataLayer events

## Testing
- `php -l includes/rest.php`
- `php -l includes/init.php`
- `php -l winshirt_ia_generate.php`
- `php -l winshirt.php`
- `php -l templates/personalizer-modal.php`


------
https://chatgpt.com/codex/tasks/task_e_6870b492bb7083299ef2a1d1c64503cc