### PR TITLE
Améliorations interface personnalisation

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -41,6 +41,12 @@
   opacity: 1;
 }
 
+.ws-modal-content input,
+.ws-modal-content textarea,
+.ws-modal-content select {
+  color: #000;
+}
+
 .ws-left {
   flex-basis: 75%;
   padding-right: 1rem;
@@ -195,7 +201,7 @@
 .ws-preview {
   position: relative;
   margin-top: 1.5rem;
-  width: 100%;
+  width: 90%;
   aspect-ratio: 4 / 5;
   background: rgba(255,255,255,0.05);
   border: 1px solid rgba(255,255,255,0.2);

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -668,7 +668,8 @@ function openModal(){
       var dy = oe.clientY - dragStart.y;
       var zonePos = $zone.position();
       var zoneW = $zone.width(), zoneH = $zone.height();
-      var itemW = $item.width(), itemH = $item.height();
+      var scale = parseFloat($item.attr('data-scale') || 1);
+      var itemW = $item.width() * scale, itemH = $item.height() * scale;
       var newX = Math.min(Math.max(zonePos.left, dragStart.itemX + dx), zonePos.left + zoneW - itemW);
       var newY = Math.min(Math.max(zonePos.top, dragStart.itemY + dy), zonePos.top + zoneH - itemH);
       $item.attr('data-x', newX).attr('data-y', newY);

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -16,6 +16,10 @@
         <div id="ws-print-zones"></div>
         <div id="ws-zone-buttons" class="ws-zone-buttons winshirt-theme-inherit"></div>
       </div>
+      <div class="ws-toggle winshirt-theme-inherit" style="margin-top:.5rem;">
+        <button id="winshirt-front-btn" class="ws-side-btn active winshirt-theme-inherit">Recto</button>
+        <button id="winshirt-back-btn" class="ws-side-btn winshirt-theme-inherit">Verso</button>
+      </div>
       <div class="ws-context-actions winshirt-theme-inherit">
         <button id="ws-remove-bg" class="ws-remove-bg winshirt-theme-inherit hidden" type="button" title="Supprimer le fond">🧼 Supprimer le fond</button>
         <button id="ws-prop-delete" class="ws-delete winshirt-theme-inherit" type="button" title="Supprimer l'élément">🗑️ Supprimer</button>
@@ -28,10 +32,6 @@
             <option value="A7">A7</option>
           </select>
         </label>
-        <div class="ws-toggle winshirt-theme-inherit">
-          <button id="winshirt-front-btn" class="ws-side-btn active winshirt-theme-inherit">Recto</button>
-          <button id="winshirt-back-btn" class="ws-side-btn winshirt-theme-inherit">Verso</button>
-        </div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- réduis la largeur du mockup dans la modale
- force la couleur du texte des champs à noir
- place les boutons Recto/Verso sous le visuel
- corrige le calcul des limites lors du déplacement des éléments

## Testing
- `php -l templates/personalizer-modal.php`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6871ecfb8c30832992297829876cf436