### PR TITLE
Add category support and toggle lotteries

### DIFF
--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -246,7 +246,7 @@ jQuery(function($){
   var aiImages = [];
   var cats = [];
   gallery.forEach(function(g){
-    var cat = g.category || g.type || '';
+    var cat = g.category || '';
     if(cat && cats.indexOf(cat) === -1) cats.push(cat);
     var $img = $('<img class="ws-gallery-thumb" />')
       .attr('src', g.url)

--- a/includes/init.php
+++ b/includes/init.php
@@ -317,7 +317,7 @@ function winshirt_render_customize_button() {
                 'id'       => $g->ID,
                 'title'    => $g->post_title,
                 'url'      => $url,
-                'category' => get_post_meta( $g->ID, '_winshirt_visual_type', true ),
+                'category' => get_post_meta( $g->ID, '_winshirt_category', true ),
             ];
         }
     }

--- a/includes/pages/visuels.php
+++ b/includes/pages/visuels.php
@@ -23,9 +23,7 @@ function winshirt_send_to_ftp($file_path) {
 }
 
 function winshirt_page_designs() {
-    $types   = ['Galerie', 'IA', 'Upload', 'SVG'];
     $filters = [
-        'type' => sanitize_text_field($_GET['type'] ?? ''),
         'date' => sanitize_text_field($_GET['date'] ?? ''),
     ];
 
@@ -64,7 +62,7 @@ function winshirt_page_designs() {
             ]);
             if ($post_id) {
                 set_post_thumbnail($post_id, $attachment_id);
-                update_post_meta($post_id, '_winshirt_visual_type', sanitize_text_field($_POST['type'] ?? ''));
+                update_post_meta($post_id, '_winshirt_category', sanitize_text_field($_POST['category'] ?? ''));
                 update_post_meta($post_id, '_winshirt_visual_validated', 'no');
                 $path = get_attached_file($attachment_id);
                 winshirt_send_to_ftp($path);
@@ -82,12 +80,7 @@ function winshirt_page_designs() {
         'order'       => 'DESC',
     ];
 
-    if ($filters['type']) {
-        $query['meta_query'][] = [
-            'key'   => '_winshirt_visual_type',
-            'value' => $filters['type'],
-        ];
-    }
+
 
     if ($filters['date']) {
         $query['date_query'][] = [

--- a/templates/admin/partials/produits-list.php
+++ b/templates/admin/partials/produits-list.php
@@ -64,7 +64,8 @@
                     </label>
                 </td>
                 <td>
-                    <select name="linked_lottery" form="winshirt-form-<?php echo esc_attr( $pid ); ?>">
+                    <button type="button" class="toggle-lottery button" data-target="lottery-<?php echo esc_attr( $pid ); ?>"><?php esc_html_e( 'Afficher les loteries', 'winshirt' ); ?></button>
+                    <select id="lottery-<?php echo esc_attr( $pid ); ?>" class="hidden" name="linked_lottery" form="winshirt-form-<?php echo esc_attr( $pid ); ?>">
                         <option value="">-</option>
                         <?php foreach ( $all_lotteries as $l ) : ?>
                             <option value="<?php echo esc_attr( $l->ID ); ?>" <?php selected( $lottery, $l->ID ); ?>><?php echo esc_html( $l->post_title ); ?></option>
@@ -86,3 +87,16 @@
     <?php endif; ?>
     </tbody>
 </table>
+<script>
+document.addEventListener('DOMContentLoaded', function(){
+    document.querySelectorAll('.toggle-lottery').forEach(function(btn){
+        btn.addEventListener('click', function(){
+            var target = btn.getAttribute('data-target');
+            var select = document.getElementById(target);
+            if(select){
+                select.classList.toggle('hidden');
+            }
+        });
+    });
+});
+</script>

--- a/templates/admin/partials/visuels-list.php
+++ b/templates/admin/partials/visuels-list.php
@@ -1,17 +1,11 @@
 <?php
 /**
  * Admin visual management interface.
- * Variables: $visuals, $filters, $types
+ * Variables: $visuals, $filters
  */
 ?>
 <form method="get" style="margin-bottom:15px;">
     <input type="hidden" name="page" value="winshirt-designs" />
-    <select name="type">
-        <option value=""><?php esc_html_e('Tous les types', 'winshirt'); ?></option>
-        <?php foreach ($types as $t) : ?>
-            <option value="<?php echo esc_attr($t); ?>" <?php selected($filters['type'], $t); ?>><?php echo esc_html($t); ?></option>
-        <?php endforeach; ?>
-    </select>
     <input type="date" name="date" value="<?php echo esc_attr($filters['date']); ?>" />
     <input type="submit" class="button" value="<?php esc_attr_e('Filtrer', 'winshirt'); ?>" />
 </form>
@@ -24,7 +18,7 @@
                 <th style="width:20px;"><input type="checkbox" id="select-all" /></th>
                 <th><?php esc_html_e('Miniature', 'winshirt'); ?></th>
                 <th><?php esc_html_e('Nom', 'winshirt'); ?></th>
-                <th><?php esc_html_e('Type', 'winshirt'); ?></th>
+                <th><?php esc_html_e('Catégorie', 'winshirt'); ?></th>
                 <th><?php esc_html_e('Date', 'winshirt'); ?></th>
                 <th><?php esc_html_e('Actions', 'winshirt'); ?></th>
             </tr>
@@ -32,14 +26,14 @@
         <tbody>
             <?php if ($visuals) : ?>
                 <?php foreach ($visuals as $visual) :
-                    $type = get_post_meta($visual->ID, '_winshirt_visual_type', true);
+                    $category = get_post_meta($visual->ID, '_winshirt_category', true);
                     $validated = get_post_meta($visual->ID, '_winshirt_visual_validated', true) === 'yes';
                 ?>
                 <tr>
                     <td><input type="checkbox" name="selected[]" value="<?php echo esc_attr($visual->ID); ?>" /></td>
                     <td><?php echo get_the_post_thumbnail($visual->ID, 'thumbnail'); ?></td>
                     <td><?php echo esc_html($visual->post_title); ?></td>
-                    <td><?php echo esc_html($type); ?></td>
+                    <td><?php echo esc_html($category); ?></td>
                     <td><?php echo esc_html(get_the_date('', $visual)); ?></td>
                     <td>
                         <?php if (!$validated) : ?>
@@ -78,12 +72,8 @@
             <td><input type="file" name="file" id="visual-file" required /></td>
         </tr>
         <tr>
-            <th scope="row"><label for="visual-type"><?php esc_html_e('Type', 'winshirt'); ?></label></th>
-            <td>
-                <select name="type" id="visual-type">
-                    <?php foreach ($types as $t) { echo '<option value="' . esc_attr($t) . '">' . esc_html($t) . '</option>'; } ?>
-                </select>
-            </td>
+            <th scope="row"><label for="visual-category"><?php esc_html_e('Catégorie', 'winshirt'); ?></label></th>
+            <td><input type="text" name="category" id="visual-category" /></td>
         </tr>
     </table>
     <p><input type="submit" class="button button-primary" value="<?php esc_attr_e('Uploader', 'winshirt'); ?>" /></p>

--- a/winshirt_ia_generate.php
+++ b/winshirt_ia_generate.php
@@ -135,7 +135,7 @@ function winshirt_rest_generate_image( WP_REST_Request $request ) {
     ]);
     if ( $visual_id ) {
         set_post_thumbnail( $visual_id, $attach_id );
-        update_post_meta( $visual_id, '_winshirt_visual_type', 'IA' );
+        update_post_meta( $visual_id, '_winshirt_category', 'IA' );
         update_post_meta( $visual_id, '_winshirt_visual_validated', 'no' );
         update_post_meta( $visual_id, '_winshirt_ai_prompt', $prompt );
         update_user_meta( $user_id, '_winshirt_ai_count', $count + 1 );


### PR DESCRIPTION
## Summary
- remove visual types and replace with categories
- add 'Afficher les loteries' toggle button for products
- adjust frontend gallery script

## Testing
- `php -l includes/pages/visuels.php`
- `php -l templates/admin/partials/visuels-list.php`
- `php -l includes/init.php`
- `php -l winshirt_ia_generate.php`
- `php -l templates/admin/partials/produits-list.php`


------
https://chatgpt.com/codex/tasks/task_e_6871f419b628832987fa2e8c62803050