### PR TITLE
Implement Supabase settings and autoload

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -179,6 +179,17 @@ function winshirt_lotteries_shortcode() {
 }
 add_shortcode( 'winshirt_lotteries', 'winshirt_lotteries_shortcode' );
 
+/**
+ * Shortcode to display the customization button and modal.
+ * Usage: [winshirt_customizer]
+ */
+function winshirt_customizer_shortcode() {
+    ob_start();
+    winshirt_render_customize_button();
+    return ob_get_clean();
+}
+add_shortcode( 'winshirt_customizer', 'winshirt_customizer_shortcode' );
+
 // Register custom post type for lotteries
 add_action('init', function () {
     register_post_type('winshirt_lottery', [
@@ -210,6 +221,9 @@ add_action('admin_init', function () {
     register_setting('winshirt_options', 'winshirt_ia_output_format');
     register_setting('winshirt_options', 'winshirt_ia_generation_limit');
     register_setting('winshirt_options', 'winshirt_ia_image_folder');
+    // Register Supabase settings
+    register_setting('winshirt_options', 'winshirt_supabase_url');
+    register_setting('winshirt_options', 'winshirt_supabase_key');
 });
 
 // Enqueue assets on WinShirt admin pages

--- a/includes/supabase-client.php
+++ b/includes/supabase-client.php
@@ -1,0 +1,55 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Simple wrapper for Supabase edge function calls.
+ */
+class Winshirt_Supabase_Client {
+    private $url;
+    private $key;
+
+    public function __construct( $url = '', $key = '' ) {
+        $this->url = $url ?: get_option( 'winshirt_supabase_url' );
+        $this->key = $key ?: get_option( 'winshirt_supabase_key' );
+    }
+
+    /**
+     * Call an edge function with optional JSON body.
+     *
+     * @param string $function Name of the edge function.
+     * @param array  $body     Optional associative array to send as JSON.
+     * @return array|WP_Error  Decoded response body or WP_Error on failure.
+     */
+    public function call_edge_function( $function, array $body = array() ) {
+        if ( ! $this->url || ! $this->key ) {
+            return new WP_Error( 'missing_keys', __( 'Supabase credentials are missing', 'winshirt' ) );
+        }
+
+        $endpoint = trailingslashit( $this->url ) . 'functions/v1/' . ltrim( $function, '/' );
+        $args     = array(
+            'headers' => array(
+                'Content-Type'  => 'application/json',
+                'apikey'        => $this->key,
+                'Authorization' => 'Bearer ' . $this->key,
+            ),
+            'body'    => ! empty( $body ) ? wp_json_encode( $body ) : null,
+            'timeout' => 20,
+        );
+
+        $response = wp_remote_post( $endpoint, $args );
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $code = wp_remote_retrieve_response_code( $response );
+        $data = json_decode( wp_remote_retrieve_body( $response ), true );
+
+        if ( $code < 200 || $code >= 300 ) {
+            return new WP_Error( 'supabase_error', __( 'Supabase request failed', 'winshirt' ), array( 'code' => $code, 'data' => $data ) );
+        }
+
+        return $data;
+    }
+}

--- a/templates/admin/partials/configuration-form.php
+++ b/templates/admin/partials/configuration-form.php
@@ -18,6 +18,18 @@
         </tr>
     </table>
 
+    <h2>Paramètres Supabase</h2>
+    <table class="form-table">
+        <tr>
+            <th scope="row"><label for="winshirt-supabase-url">URL Supabase</label></th>
+            <td><input name="winshirt_supabase_url" id="winshirt-supabase-url" type="text" value="<?php echo esc_attr(get_option('winshirt_supabase_url')); ?>" class="regular-text" /></td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="winshirt-supabase-key">Clé publique</label></th>
+            <td><input name="winshirt_supabase_key" id="winshirt-supabase-key" type="text" value="<?php echo esc_attr(get_option('winshirt_supabase_key')); ?>" class="regular-text" /></td>
+        </tr>
+    </table>
+
     <h2>Paramètres IA</h2>
     <table class="form-table">
         <tr>

--- a/winshirt.php
+++ b/winshirt.php
@@ -11,15 +11,26 @@ defined('ABSPATH') || exit;
 define('WINSHIRT_PATH', plugin_dir_path(__FILE__));
 define('WINSHIRT_URL', plugin_dir_url(__FILE__));
 
-require_once WINSHIRT_PATH . 'includes/init.php';
-require_once WINSHIRT_PATH . 'includes/pages/mockups.php';
-require_once WINSHIRT_PATH . 'includes/pages/visuels.php';
-require_once WINSHIRT_PATH . 'includes/pages/produits.php';
-require_once WINSHIRT_PATH . 'includes/pages/loteries.php';
-require_once WINSHIRT_PATH . 'includes/pages/commandes.php';
-require_once WINSHIRT_PATH . 'includes/pages/configuration.php';
+/**
+ * Automatically load all PHP files from the given directory.
+ *
+ * @param string $dir Absolute path to directory.
+ */
+function winshirt_load_files( $dir ) {
+    foreach ( glob( trailingslashit( $dir ) . '*.php' ) as $file ) {
+        require_once $file;
+    }
+    foreach ( glob( trailingslashit( $dir ) . '*', GLOB_ONLYDIR ) as $sub ) {
+        winshirt_load_files( $sub );
+    }
+}
+
+winshirt_load_files( WINSHIRT_PATH . 'includes' );
+if ( is_dir( WINSHIRT_PATH . 'admin' ) ) {
+    winshirt_load_files( WINSHIRT_PATH . 'admin' );
+}
+
 require_once WINSHIRT_PATH . 'winshirt_ia_generate.php';
-require_once WINSHIRT_PATH . 'includes/rest.php';
 
 // Register uninstall hook
 register_uninstall_hook(__FILE__, 'winshirt_plugin_uninstall');


### PR DESCRIPTION
## Summary
- add automatic PHP file loader in main plugin file
- introduce `Winshirt_Supabase_Client` wrapper
- register Supabase options and expose them in admin configuration form
- provide `[winshirt_customizer]` shortcode

## Testing
- `php -l winshirt.php`
- `php -l includes/supabase-client.php`
- `php -l includes/init.php`
- `php -l templates/admin/partials/configuration-form.php`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68720613a6648329904add44576343a4