### PR TITLE
Hide lottery selector for pre-linked products

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -403,6 +403,11 @@ function winshirt_render_lottery_selector() {
     }
 
     $pid      = $product->get_id();
+    $linked   = absint( get_post_meta( $pid, 'linked_lottery', true ) );
+    if ( $linked ) {
+        winshirt_render_lottery_info();
+        return;
+    }
     $tickets  = absint( get_post_meta( $pid, 'loterie_tickets', true ) );
     if ( $tickets < 1 ) {
         return;


### PR DESCRIPTION
## Summary
- check if a product is linked to a lottery before rendering the lottery dropdown
- when a linked lottery exists, show the info card only

## Testing
- `php -l includes/init.php`

------
https://chatgpt.com/codex/tasks/task_e_68736401d6d483299a70160ee4455411