### PR TITLE
Enhance personalization modal UI

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -189,10 +189,11 @@
   background: rgba(255,255,255,0.2);
 }
 .ws-gallery {
-  display: flex;
-  flex-wrap: nowrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill,minmax(64px,1fr));
   gap: .5rem;
-  overflow-x: auto;
+  max-height: 250px;
+  overflow-y: auto;
   padding-bottom: .5rem;
 }
 .ws-gallery-thumb {
@@ -204,6 +205,10 @@
   border-radius: .25rem;
   cursor: pointer;
   transition: transform .2s;
+}
+.ws-gallery-thumb.selected {
+  outline: 2px solid #fff;
+  outline-offset: -2px;
 }
 .ws-gallery-thumb:hover {
   transform: scale(1.05);
@@ -307,6 +312,11 @@
   gap: .5rem;
   margin-top: 1.5rem;
   width: 100%;
+  position: sticky;
+  bottom: 0;
+  background: rgba(0,0,0,0.4);
+  backdrop-filter: blur(8px);
+  padding-bottom: .5rem;
 }
 .ws-toggle {
   display: flex;
@@ -487,9 +497,14 @@
   display: none;
   flex-direction: column;
   gap: .5rem;
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity .3s ease-in-out, transform .3s ease-in-out;
 }
 .ws-sidebar.show {
   display: flex;
+  opacity: 1;
+  transform: none;
 }
 .ws-tabs-header::-webkit-scrollbar {
   display: none;

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -302,6 +302,8 @@ jQuery(function($){
   });
 
   $gallery.on('click', '.ws-gallery-thumb', function(){
+    $gallery.find('.ws-gallery-thumb').removeClass('selected');
+    $(this).addClass('selected');
     addItem('image', $(this).attr('src'));
   });
 
@@ -950,6 +952,13 @@ function openModal(){
     captureAllSides();
     if(window.dataLayer){ dataLayer.push({event:'customize_completed', product_id:$modal.data('product-id')}); }
     closeModal();
+  });
+
+  // Test capture sans fermer la modale
+  $('#btn-test-capture').on('click', function(){
+    captureAllSides().then(function(){
+      alert('Capture enregistrée');
+    });
   });
 
   switchSide('front');

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -20,19 +20,6 @@
         <button id="winshirt-front-btn" class="ws-side-btn active winshirt-theme-inherit" aria-label="Recto">Recto</button>
         <button id="winshirt-back-btn" class="ws-side-btn winshirt-theme-inherit" aria-label="Verso">Verso</button>
       </div>
-      <div class="ws-context-actions ws-section winshirt-theme-inherit">
-        <button id="ws-remove-bg" class="ws-remove-bg winshirt-theme-inherit hidden" type="button" title="Supprimer le fond" aria-label="Supprimer le fond">🧼 Supprimer le fond</button>
-        <button id="ws-prop-delete" class="ws-delete winshirt-theme-inherit" type="button" title="Supprimer l'élément" aria-label="Supprimer l'élément">🗑️ Supprimer</button>
-        <label class="ws-format-label">📐
-          <select id="ws-format-select" class="ws-format-select winshirt-theme-inherit">
-            <option value="A3">A3</option>
-            <option value="A4">A4</option>
-            <option value="A5">A5</option>
-            <option value="A6">A6</option>
-            <option value="A7">A7</option>
-          </select>
-        </label>
-      </div>
     </div>
 
     <div class="ws-right winshirt-theme-inherit">
@@ -127,6 +114,19 @@
         <label class="ws-color-field winshirt-theme-inherit">🎨 <?php esc_html_e( 'Couleur', 'winshirt' ); ?>
           <input type="color" id="ws-prop-color" class="winshirt-theme-inherit" value="#000000">
         </label>
+        <div class="ws-context-actions winshirt-theme-inherit">
+          <button id="ws-remove-bg" class="ws-remove-bg winshirt-theme-inherit hidden" type="button" title="Supprimer le fond" aria-label="Supprimer le fond">🧼 Supprimer le fond</button>
+          <button id="ws-prop-delete" class="ws-delete winshirt-theme-inherit" type="button" title="Supprimer l'élément" aria-label="Supprimer l'élément">🗑️ Supprimer</button>
+          <label class="ws-format-label">📐
+            <select id="ws-format-select" class="ws-format-select winshirt-theme-inherit">
+              <option value="A3">A3</option>
+              <option value="A4">A4</option>
+              <option value="A5">A5</option>
+              <option value="A6">A6</option>
+              <option value="A7">A7</option>
+            </select>
+          </label>
+        </div>
       </div>
 
       <div class="ws-colors winshirt-theme-inherit"></div>
@@ -138,6 +138,7 @@
         <div class="ws-actions ws-section winshirt-theme-inherit">
           <small class="ws-size-note">Taille réelle estimée sur un visuel 1500x1500px – affichage à titre indicatif.</small>
           <button id="btn-valider-personnalisation" class="ws-validate winshirt-theme-inherit" aria-label="Valider la personnalisation">Valider la personnalisation</button>
+          <button id="btn-test-capture" class="ws-validate winshirt-theme-inherit" aria-label="Test capture">Test Capture</button>
         </div>
 
     </div>


### PR DESCRIPTION
## Summary
- move context actions into sidebar panel
- highlight selected gallery item and use grid layout
- add sticky action bar with new test capture button
- improve sidebar transition effects

## Testing
- `php -l templates/personalizer-modal.php`

------
https://chatgpt.com/codex/tasks/task_e_6874c0d58c2c8329b782df3c37a76df4