### PR TITLE
Improve mobile T-shirt modal layout

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -837,3 +837,23 @@
   position:sticky;
   bottom:0;
 }
+
+/* Mobile preview layout */
+.ws-mobile .ws-left {
+  position:relative;
+  top:auto;
+  height:auto;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+}
+.ws-mobile .ws-preview {
+  margin-top:0;
+  width:100%;
+  max-height:calc(100dvh - 150px);
+}
+.ws-mobile .ws-toggle {
+  justify-content:center;
+  gap:1rem;
+  margin-top:.5rem;
+}

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -169,13 +169,24 @@ jQuery(function($){
   function checkMobile(){
     if(window.innerWidth <= 768){
       $modal.addClass('ws-mobile winshirt-personnalisation-mobile');
+      updatePreviewHeight();
     } else {
       $modal.removeClass('ws-mobile winshirt-personnalisation-mobile');
       $modal.find('.ws-right').removeClass('show');
+      $modal.find('.ws-preview').css('max-height','');
     }
     if($zoneButtons.parent()[0] !== $modal.find('.ws-preview')[0]){
       $zoneButtons.appendTo($modal.find('.ws-preview'));
     }
+  }
+
+  function updatePreviewHeight(){
+    if(!$modal.hasClass('ws-mobile')) return;
+    var toolsH = $modal.find('.ws-tools').outerHeight() || 0;
+    var toggleH = $modal.find('.ws-toggle').outerHeight() || 0;
+    var offset = toolsH + toggleH + 32; // padding/margins
+    var max = window.innerHeight - offset;
+    $modal.find('.ws-preview').css('max-height', max + 'px');
   }
 
   function debugHiddenElements(){
@@ -503,6 +514,7 @@ jQuery(function($){
 
 function openModal(){
   checkMobile();
+  updatePreviewHeight();
   loadState();
   loadAiImages();
   renderAiGallery();
@@ -574,7 +586,10 @@ function openModal(){
   });
   $modal.on('click', function(e){ if($(e.target).is('.ws-modal')) closeModal(); });
   $(document).on('keyup', function(e){ if(e.key === 'Escape') closeModal(); });
-  $(window).on('resize', checkMobile);
+  $(window).on('resize', function(){
+    checkMobile();
+    updatePreviewHeight();
+  });
 
   $('.ws-tab-button').on('click', function(){
     openTab($(this).data('tab'));


### PR DESCRIPTION
## Summary
- adjust preview area height on mobile
- reposition Recto/Verso toggle
- keep layout responsive while avoiding overlap with tool buttons

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6874c72164b08329a5e9a5b87265a918