### PR TITLE
Style custom badge like lottery thumbnails

### DIFF
--- a/assets/css/winshirt-badge.css
+++ b/assets/css/winshirt-badge.css
@@ -1,0 +1,17 @@
+.ws-customizable-badge {
+    position: absolute;
+    transform: rotate(13deg);
+    top: 10px;
+    right: 0px;
+    background: rgba(60, 110, 230, 0.15);
+    color: #376af2;
+    padding: 3px 14px;
+    font-size: 0.89rem;
+    font-weight: 600;
+    border-radius: 16px;
+    letter-spacing: 0.1em;
+    pointer-events: none;
+    z-index: 2;
+    box-shadow: 0 2px 7px rgba(100, 120, 220, 0.10);
+    backdrop-filter: blur(2px);
+}

--- a/includes/init.php
+++ b/includes/init.php
@@ -23,6 +23,13 @@ add_action('wp_enqueue_scripts', function () {
     }
 });
 
+// Enqueue badge style on shop listings
+add_action('wp_enqueue_scripts', function () {
+    if (is_shop() || is_product_category() || is_product_tag()) {
+        wp_enqueue_style('winshirt-badge', WINSHIRT_URL . 'assets/css/winshirt-badge.css', [], '1.0');
+    }
+});
+
 
 // Enqueue assets when the lottery shortcode is present
 add_action('wp_enqueue_scripts', function(){
@@ -856,6 +863,18 @@ function winshirt_push_purchase_datalayer( $order_id ){
     echo '<script>window.dataLayer=window.dataLayer||[];dataLayer.push(' . wp_json_encode( $data ) . ');</script>';
 }
 add_action( 'woocommerce_thankyou', 'winshirt_push_purchase_datalayer' );
+
+// Display "Personnalisable" badge on product thumbnails in shop
+function winshirt_shop_customizable_badge() {
+    global $product;
+    if ( ! $product instanceof WC_Product ) {
+        return;
+    }
+    if ( get_post_meta( $product->get_id(), '_winshirt_enabled', true ) === 'yes' ) {
+        echo '<span class="ws-customizable-badge">' . esc_html__( 'Personnalisable', 'winshirt' ) . '</span>';
+    }
+}
+add_action( 'woocommerce_before_shop_loop_item_title', 'winshirt_shop_customizable_badge', 5 );
 
 // ----- Account section for saved customizations -----
 add_action( 'init', 'winshirt_account_endpoint' );


### PR DESCRIPTION
## Summary
- match customizable badge appearance with lottery thumbnail badges
- enqueue badge stylesheet on shop pages
- show a "Personnalisable" badge when the product has customization enabled

## Testing
- `php -l includes/init.php`


------
https://chatgpt.com/codex/tasks/task_e_6874db2d60e48329b01cfdd9f2d91582