### PR TITLE
Add AI gallery to customizer

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -348,6 +348,27 @@ function winshirt_render_customize_button() {
         }
     }
     $ws_gallery = wp_json_encode( $gallery );
+
+    // Retrieve validated AI generated visuals
+    $ai_posts = get_posts([
+        'post_type'   => 'winshirt_visual',
+        'numberposts' => -1,
+        'orderby'     => 'date',
+        'order'       => 'DESC',
+        'meta_query'  => [
+            [ 'key' => '_winshirt_visual_validated', 'value' => 'yes' ],
+            [ 'key' => '_winshirt_category', 'value' => 'IA' ],
+        ],
+    ]);
+    $ai_gallery = [];
+    foreach ( $ai_posts as $a ) {
+        $url = get_the_post_thumbnail_url( $a->ID, 'full' );
+        if ( $url ) {
+            $ai_gallery[] = $url;
+        }
+    }
+    $ws_ai_gallery = wp_json_encode( $ai_gallery );
+
     include WINSHIRT_PATH . 'templates/personalizer-modal.php';
 }
 // Affiche le bouton juste sous le prix, avant les billets de loterie

--- a/readme.txt
+++ b/readme.txt
@@ -16,6 +16,7 @@ L'onglet "Visuels" permet d'importer ou supprimer des images. Les visuels peuven
 
 ## Personnalisation de produits
 Un bouton "Personnaliser ce produit" ouvre un modale sur la fiche produit pour choisir un design, saisir du texte ou importer une image. Les sélections sont temporairement sauvegardées via localStorage et sont automatiquement restaurées lors de la réouverture du modale.
+L'onglet IA comporte maintenant une galerie listant les visuels générés par l'ensemble des visiteurs.
 
 ## Gestion des loteries
 Une page "Loteries" permet de créer et d'administrer les tirages. Chaque loterie peut être liée à un produit WooCommerce, disposer de dates de début/fin, de lots à gagner et d'une animation personnalisée. Les participants enregistrés et leur nombre sont visibles depuis cette interface.

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -4,6 +4,7 @@
   data-colors='<?php echo esc_attr( $ws_colors ?? '[]' ); ?>'
   data-zones='<?php echo esc_attr( $ws_zones ?? '[]' ); ?>'
   data-gallery='<?php echo esc_attr( $ws_gallery ?? '[]' ); ?>'
+  data-ai-gallery='<?php echo esc_attr( $ws_ai_gallery ?? '[]' ); ?>'
   data-product-id="<?php echo esc_attr( $pid ); ?>">
   
   <div class="ws-modal-content winshirt-theme-inherit">


### PR DESCRIPTION
## Summary
- provide gallery of AI visuals in front-end modal
- load validated AI posts on the server
- persist user generated AI images separately
- mention the new feature in the readme

## Testing
- `php -l includes/init.php`
- `php -l winshirt_ia_generate.php`
- `php -l templates/personalizer-modal.php`

------
https://chatgpt.com/codex/tasks/task_e_6875f86380808329aca2a7f192a34850