### PR TITLE
Adjust preview UI

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -64,6 +64,7 @@
   height: 100%;
   overflow: hidden;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
 }
@@ -234,7 +235,7 @@
   margin-top: 0;
 }
 .ws-preview-img {
-  max-width: 100%;
+  max-width: 90%;
   max-height: 100%;
   object-fit: contain;
 }
@@ -341,12 +342,7 @@
   flex-wrap: wrap;
   justify-content: center;
   gap: 10px;
-  position: absolute;
-  bottom: 10px;
-  left: 50%;
-  transform: translateX(-50%);
-  margin-top: 0;
-  z-index: 5;
+  margin-top: .5rem;
 }
 .ws-zone-btn {
   background: rgba(255,255,255,0.1);

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -182,8 +182,8 @@ jQuery(function($){
       $modal.find('.ws-right').removeClass('show');
       $modal.find('.ws-preview').css('max-height','');
     }
-    if($zoneButtons.parent()[0] !== $modal.find('.ws-preview')[0]){
-      $zoneButtons.appendTo($modal.find('.ws-preview'));
+    if($zoneButtons.parent()[0] === $modal.find('.ws-preview')[0]){
+      $zoneButtons.insertAfter($modal.find('.ws-preview'));
     }
   }
 

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -10,17 +10,17 @@
   <div class="ws-modal-content winshirt-theme-inherit">
 
     <div class="ws-left winshirt-theme-inherit">
+      <div class="ws-toggle winshirt-theme-inherit" style="margin-bottom:.5rem;">
+        <button id="winshirt-front-btn" class="ws-side-btn active winshirt-theme-inherit" aria-label="Recto">Recto</button>
+        <button id="winshirt-back-btn" class="ws-side-btn winshirt-theme-inherit" aria-label="Verso">Verso</button>
+      </div>
       <div class="ws-preview mockup-fixed ws-section winshirt-theme-inherit">
         <img src="<?php echo esc_url( $default_front ?? '' ); ?>" alt="Mockup" class="ws-preview-img" />
         <div class="ws-color-overlay winshirt-theme-inherit"></div>
         <div id="ws-canvas" class="ws-canvas"></div>
         <div id="ws-print-zones"></div>
-        <div id="ws-zone-buttons" class="ws-zone-buttons winshirt-theme-inherit"></div>
       </div>
-      <div class="ws-toggle winshirt-theme-inherit" style="margin-top:.5rem;">
-        <button id="winshirt-front-btn" class="ws-side-btn active winshirt-theme-inherit" aria-label="Recto">Recto</button>
-        <button id="winshirt-back-btn" class="ws-side-btn winshirt-theme-inherit" aria-label="Verso">Verso</button>
-      </div>
+      <div id="ws-zone-buttons" class="ws-zone-buttons winshirt-theme-inherit"></div>
     </div>
 
     <div class="ws-right winshirt-theme-inherit">


### PR DESCRIPTION
## Summary
- tweak layout of personalizer modal
- show zone buttons below the shirt
- move side toggle above preview
- shrink preview image width
- keep left column vertical so controls stack

## Testing
- `php -l templates/personalizer-modal.php`


------
https://chatgpt.com/codex/tasks/task_e_687617a8022883298512de7f1c90bd60