### PR TITLE
Add pricing support for print zones

### DIFF
--- a/assets/js/winshirt-mockups.js
+++ b/assets/js/winshirt-mockups.js
@@ -69,8 +69,9 @@ jQuery(function ($) {
     var $row = $('.zone-row[data-index="' + index + '"]');
     var side = $row.find('.zone-side').val();
     var fmt = $row.find('.zone-format').val();
+    var price = parseFloat($row.find('.zone-price').val() || 0);
     var $canvas = side === 'back' ? $('#mockup-canvas-back') : $('#mockup-canvas-front');
-    var $zone = $('<div class="print-zone" data-index="' + index + '" data-side="' + side + '" data-format="' + fmt + '">' + fmt + '</div>')
+    var $zone = $('<div class="print-zone" data-index="' + index + '" data-side="' + side + '" data-format="' + fmt + '">' + fmt + '<span class="admin-zone-price">' + price + '€</span></div>')
       .css({ top: '10%', left: '10%', width: '20%', height: '20%' });
     $canvas.append($zone);
     syncZone($zone);
@@ -98,6 +99,14 @@ jQuery(function ($) {
     var $row = $(this).closest('.zone-row');
     var idx = $row.data('index');
     var fmt = $(this).val();
-    $('.print-zone[data-index="' + idx + '"]').attr('data-format', fmt).text(fmt);
+    var $pz = $('.print-zone[data-index="' + idx + '"]').attr('data-format', fmt);
+    $pz.contents().filter(function(){return this.nodeType===3;}).first().replaceWith(fmt);
+  });
+
+  $(document).on('input change', '.zone-price', function(){
+    var $row = $(this).closest('.zone-row');
+    var idx = $row.data('index');
+    var price = parseFloat($(this).val() || 0);
+    $('.print-zone[data-index="' + idx + '"]').find('.admin-zone-price').text(price + '€');
   });
 });

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -28,6 +28,7 @@ jQuery(function($){
   var $frontField = $('#winshirt-front-image-field');
   var $backField = $('#winshirt-back-image-field');
   var $customField = $('#winshirt-custom-data-field');
+  var $extraField = $('#winshirt-extra-price-field');
   var $prodLocal = $('#winshirt-production-image');
   var $frontLocal = $('#winshirt-front-image');
   var $backLocal = $('#winshirt-back-image');
@@ -459,6 +460,9 @@ jQuery(function($){
     $zoneButtons.find('.ws-zone-btn[data-index="'+index+'"]').addClass('active selected');
     $modal.find('.ws-print-zone').removeClass('active').hide();
     $modal.find('.ws-print-zone[data-index="'+index+'"]').show().addClass('active');
+    if($extraField.length && zones[index]){
+      $extraField.val(zones[index].price || 0);
+    }
     applyClip();
     if(activeItem){ updateDebug(activeItem); }
   }

--- a/includes/pages/mockups.php
+++ b/includes/pages/mockups.php
@@ -75,6 +75,7 @@ function winshirt_page_mockups() {
                     'name'   => sanitize_text_field($z['name']),
                     'format' => in_array($z['format'], ['A3','A4','A5','A6','A7']) ? $z['format'] : 'A4',
                     'side'   => $z['side'] === 'back' ? 'back' : 'front',
+                    'price'  => floatval($z['price'] ?? 0),
                     'top'    => floatval($z['top'] ?? 0),
                     'left'   => floatval($z['left'] ?? 0),
                     'width'  => floatval($z['width'] ?? 0),

--- a/templates/admin/partials/mockups-list.php
+++ b/templates/admin/partials/mockups-list.php
@@ -112,6 +112,9 @@
                         <option value="back" <?php selected($z['side'],'back'); ?>><?php esc_html_e('Verso','winshirt'); ?></option>
                     </select>
                 </label>
+                <label><?php esc_html_e('Prix', 'winshirt'); ?>
+                    <input type="number" step="0.01" class="zone-price" name="zones[<?php echo $zindex; ?>][price]" value="<?php echo esc_attr($z['price'] ?? ''); ?>" />
+                </label>
                 <input type="hidden" name="zones[<?php echo $zindex; ?>][top]" class="zone-top" value="<?php echo esc_attr($z['top']); ?>" />
                 <input type="hidden" name="zones[<?php echo $zindex; ?>][left]" class="zone-left" value="<?php echo esc_attr($z['left']); ?>" />
                 <input type="hidden" name="zones[<?php echo $zindex; ?>][width]" class="zone-width" value="<?php echo esc_attr($z['width']); ?>" />
@@ -140,6 +143,7 @@
                     <option value="back"><?php esc_html_e('Verso','winshirt'); ?></option>
                 </select>
             </label>
+            <label><?php esc_html_e('Prix', 'winshirt'); ?> <input type="number" step="0.01" class="zone-price" name="zones[%i%][price]" value="0" /></label>
             <input type="hidden" name="zones[%i%][top]" class="zone-top" value="10" />
             <input type="hidden" name="zones[%i%][left]" class="zone-left" value="10" />
             <input type="hidden" name="zones[%i%][width]" class="zone-width" value="20" />
@@ -151,13 +155,19 @@
         <div id="mockup-canvas-front" class="mockup-canvas">
             <?php if ($front) { echo wp_get_attachment_image($front, 'medium'); } ?>
             <?php foreach ($zones as $i => $z) : if ($z['side'] !== 'front') continue; ?>
-                <div class="print-zone" data-index="<?php echo esc_attr($i); ?>" data-side="front" data-format="<?php echo esc_attr($z['format']); ?>" style="top:<?php echo esc_attr($z['top']); ?>%;left:<?php echo esc_attr($z['left']); ?>%;width:<?php echo esc_attr($z['width']); ?>%;height:<?php echo esc_attr($z['height']); ?>%;"><?php echo esc_html($z['format']); ?></div>
+                <div class="print-zone" data-index="<?php echo esc_attr($i); ?>" data-side="front" data-format="<?php echo esc_attr($z['format']); ?>" style="top:<?php echo esc_attr($z['top']); ?>%;left:<?php echo esc_attr($z['left']); ?>%;width:<?php echo esc_attr($z['width']); ?>%;height:<?php echo esc_attr($z['height']); ?>%;">
+                    <?php echo esc_html($z['format']); ?>
+                    <?php if(isset($z['price'])) : ?><span class="admin-zone-price"><?php echo esc_html($z['price']); ?>€</span><?php endif; ?>
+                </div>
             <?php endforeach; ?>
         </div>
         <div id="mockup-canvas-back" class="mockup-canvas">
             <?php if ($back) { echo wp_get_attachment_image($back, 'medium'); } ?>
             <?php foreach ($zones as $i => $z) : if ($z['side'] !== 'back') continue; ?>
-                <div class="print-zone" data-index="<?php echo esc_attr($i); ?>" data-side="back" data-format="<?php echo esc_attr($z['format']); ?>" style="top:<?php echo esc_attr($z['top']); ?>%;left:<?php echo esc_attr($z['left']); ?>%;width:<?php echo esc_attr($z['width']); ?>%;height:<?php echo esc_attr($z['height']); ?>%;"><?php echo esc_html($z['format']); ?></div>
+                <div class="print-zone" data-index="<?php echo esc_attr($i); ?>" data-side="back" data-format="<?php echo esc_attr($z['format']); ?>" style="top:<?php echo esc_attr($z['top']); ?>%;left:<?php echo esc_attr($z['left']); ?>%;width:<?php echo esc_attr($z['width']); ?>%;height:<?php echo esc_attr($z['height']); ?>%;">
+                    <?php echo esc_html($z['format']); ?>
+                    <?php if(isset($z['price'])) : ?><span class="admin-zone-price"><?php echo esc_html($z['price']); ?>€</span><?php endif; ?>
+                </div>
             <?php endforeach; ?>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- store zone pricing in admin UI and meta
- show zone price labels in mockup editor
- pass price data to the modal and apply selected zone price as extra fee
- ensure print zones aren't duplicated when front/back use the same mockup

## Testing
- `php -l includes/init.php`
- `php -l includes/pages/mockups.php`
- `node --check assets/js/winshirt-modal.js`
- `node --check assets/js/winshirt-mockups.js`


------
https://chatgpt.com/codex/tasks/task_e_68777a0e42548329b9e32f4fb5debaed