### PR TITLE
Improve customization previews

### DIFF
--- a/assets/css/winshirt-theme.css
+++ b/assets/css/winshirt-theme.css
@@ -51,4 +51,13 @@
   max-width: 45%;
   height: auto;
   border: 1px solid #ddd;
+  cursor: pointer;
+}
+
+.winshirt-cart-custom img,
+.winshirt-order-preview img {
+  max-width: 60px;
+  height: auto;
+  border: 1px solid #ddd;
+  margin-right: 0.25rem;
 }

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -59,6 +59,10 @@ jQuery(function($){
     if(front){ $imgs.append('<img src="'+front+'" alt="Recto" class="ws-custom-img" />'); }
     if(back){ $imgs.append('<img src="'+back+'" alt="Verso" class="ws-custom-img" />'); }
   }
+
+  $(document).on('click', '#ws-custom-preview img', function(){
+    window.open($(this).attr('src'), '_blank');
+  });
   var $prodLocal = $('#winshirt-production-image');
   var $frontLocal = $('#winshirt-front-image');
   var $backLocal = $('#winshirt-back-image');
@@ -286,6 +290,7 @@ jQuery(function($){
     };
     localStorage.setItem('winshirt_custom', JSON.stringify(data));
     uploadMockup();
+    updateDisplayedPrice();
   }
 
   function loadState(){

--- a/includes/init.php
+++ b/includes/init.php
@@ -585,6 +585,23 @@ function winshirt_display_cart_item_data( $item_data, $cart_item ) {
 }
 add_filter( 'woocommerce_get_item_data', 'winshirt_display_cart_item_data', 10, 2 );
 
+function winshirt_cart_item_preview( $name, $cart_item, $cart_item_key ) {
+    $front = $cart_item['winshirt_front_image'] ?? '';
+    $back  = $cart_item['winshirt_back_image'] ?? '';
+    if ( $front || $back ) {
+        $html = '';
+        if ( $front ) {
+            $html .= '<img src="' . esc_url( $front ) . '" alt="front" />';
+        }
+        if ( $back ) {
+            $html .= '<img src="' . esc_url( $back ) . '" alt="back" />';
+        }
+        $name .= '<div class="winshirt-cart-custom">' . $html . '</div>';
+    }
+    return $name;
+}
+add_filter( 'woocommerce_cart_item_name', 'winshirt_cart_item_preview', 10, 3 );
+
 function winshirt_save_lottery_order_item_meta( $item, $cart_item_key, $values, $order ) {
     if ( ! empty( $values['winshirt_lotteries'] ) ) {
         $item->update_meta_data( '_winshirt_lotteries', $values['winshirt_lotteries'] );
@@ -685,6 +702,28 @@ function winshirt_increment_lottery_participants( $order_id ) {
 
 // Display related lottery info under each product line in emails and thankyou page
 add_filter( 'woocommerce_order_item_meta_end', 'winshirt_display_lottery_in_email', 10, 4 );
+
+function winshirt_order_item_preview( $item_id, $item, $order, $plain_text ) {
+    $front = $item->get_meta( 'winshirt_front_preview' );
+    $back  = $item->get_meta( 'winshirt_back_preview' );
+    if ( ! $front && ! $back ) {
+        return;
+    }
+    if ( $plain_text ) {
+        if ( $front ) echo "Recto : $front\n";
+        if ( $back )  echo "Verso : $back\n";
+    } else {
+        $html = '';
+        if ( $front ) {
+            $html .= '<img src="' . esc_url( $front ) . '" alt="front" />';
+        }
+        if ( $back ) {
+            $html .= '<img src="' . esc_url( $back ) . '" alt="back" />';
+        }
+        echo '<p class="winshirt-order-preview">' . $html . '</p>';
+    }
+}
+add_action( 'woocommerce_order_item_meta_end', 'winshirt_order_item_preview', 5, 4 );
 
 /**
  * Append a message about the associated lottery below the order item.

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -5,9 +5,6 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  * Handle upload of production image captured client side.
  */
 function winshirt_rest_upload_production_image( WP_REST_Request $request ) {
-    if ( ! is_user_logged_in() ) {
-        return new WP_REST_Response( [ 'message' => 'forbidden' ], 403 );
-    }
     $nonce = $request->get_header( 'X-WP-Nonce' );
     if ( ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
         return new WP_REST_Response( [ 'message' => 'invalid_nonce' ], 403 );
@@ -44,9 +41,6 @@ function winshirt_rest_upload_production_image( WP_REST_Request $request ) {
  * Upload temporary preview mockup and return URLs of HD and low resolution images.
  */
 function winshirt_rest_upload_mockup( WP_REST_Request $request ) {
-    if ( ! is_user_logged_in() ) {
-        return new WP_REST_Response( [ 'message' => 'forbidden' ], 403 );
-    }
     $nonce = $request->get_header( 'X-WP-Nonce' );
     if ( ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
         return new WP_REST_Response( [ 'message' => 'invalid_nonce' ], 403 );
@@ -93,9 +87,6 @@ function winshirt_rest_upload_mockup( WP_REST_Request $request ) {
  * Upload temporary custom side image (front/back).
  */
 function winshirt_rest_upload_custom_side( WP_REST_Request $request ) {
-    if ( ! is_user_logged_in() ) {
-        return new WP_REST_Response( [ 'message' => 'forbidden' ], 403 );
-    }
     $nonce = $request->get_header( 'X-WP-Nonce' );
     if ( ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
         return new WP_REST_Response( [ 'message' => 'invalid_nonce' ], 403 );
@@ -137,18 +128,18 @@ add_action( 'rest_api_init', function() {
     register_rest_route( 'winshirt/v1', '/upload-production-image', [
         'methods'             => WP_REST_Server::CREATABLE,
         'callback'            => 'winshirt_rest_upload_production_image',
-        'permission_callback' => function(){ return is_user_logged_in(); },
+        'permission_callback' => '__return_true',
     ] );
 
     register_rest_route( 'winshirt/v1', '/upload-mockup', [
         'methods'             => WP_REST_Server::CREATABLE,
         'callback'            => 'winshirt_rest_upload_mockup',
-        'permission_callback' => function(){ return is_user_logged_in(); },
+        'permission_callback' => '__return_true',
     ] );
 
     register_rest_route( 'winshirt/v1', '/upload-custom-side', [
         'methods'             => WP_REST_Server::CREATABLE,
         'callback'            => 'winshirt_rest_upload_custom_side',
-        'permission_callback' => function(){ return is_user_logged_in(); },
+        'permission_callback' => '__return_true',
     ] );
 });


### PR DESCRIPTION
## Summary
- show custom preview images clickable and styled
- update product price whenever customization state saves
- display custom images in cart and order views
- allow customization uploads without requiring login

## Testing
- `php -l includes/init.php`
- `php -l includes/rest.php`
- `node --check assets/js/winshirt-modal.js`


------
https://chatgpt.com/codex/tasks/task_e_6877bda06a808329983e792347ed0a94