### PR TITLE
Fix custom zone pricing calculations

### DIFF
--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -29,13 +29,13 @@ jQuery(function($){
   var $backField = $('#winshirt-back-image-field');
   var $customField = $('#winshirt-custom-data-field');
   var $extraField = $('#winshirt-extra-price-field');
-  var basePrice = null;
   var $priceEl = $('.summary .price').first();
-  if($priceEl.length){
+  var basePrice = parseFloat($modal.data('base-price'));
+  if(isNaN(basePrice) && $priceEl.length){
     var num = $priceEl.text().replace(/[^0-9.,]/g,'').replace(',','.');
     basePrice = parseFloat(num);
-    if(isNaN(basePrice)) basePrice = null;
   }
+  if(isNaN(basePrice)) basePrice = null;
 
   function updateDisplayedPrice(){
     if(basePrice===null || !$priceEl.length) return;

--- a/includes/pages/mockups.php
+++ b/includes/pages/mockups.php
@@ -75,7 +75,7 @@ function winshirt_page_mockups() {
                     'name'   => sanitize_text_field($z['name']),
                     'format' => in_array($z['format'], ['A3','A4','A5','A6','A7']) ? $z['format'] : 'A4',
                     'side'   => $z['side'] === 'back' ? 'back' : 'front',
-                    'price'  => floatval($z['price'] ?? 0),
+                    'price'  => floatval(str_replace(',', '.', $z['price'] ?? 0)),
                     'top'    => floatval($z['top'] ?? 0),
                     'left'   => floatval($z['left'] ?? 0),
                     'width'  => floatval($z['width'] ?? 0),

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -5,7 +5,8 @@
   data-zones='<?php echo esc_attr( $ws_zones ?? '[]' ); ?>'
   data-gallery='<?php echo esc_attr( $ws_gallery ?? '[]' ); ?>'
   data-ai-gallery='<?php echo esc_attr( $ws_ai_gallery ?? '[]' ); ?>'
-  data-product-id="<?php echo esc_attr( $pid ); ?>">
+  data-product-id="<?php echo esc_attr( $pid ); ?>"
+  data-base-price="<?php echo esc_attr( $product instanceof WC_Product ? $product->get_price() : 0 ); ?>">
   
   <div class="ws-modal-content winshirt-theme-inherit">
 


### PR DESCRIPTION
## Summary
- handle comma decimals when saving print zone prices
- expose product price to the customization modal
- use new base price data in the modal JS

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687938d894648329a5a9e7bdb5f4b0ba