### PR TITLE
Fix customization side pricing & capture sizing

### DIFF
--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -29,20 +29,40 @@ jQuery(function($){
   var $backField = $('#winshirt-back-image-field');
   var $customField = $('#winshirt-custom-data-field');
   var $extraField = $('#winshirt-extra-price-field');
-  var $priceEl = $('.summary .price').first();
+  var $priceEl = $('.summary .price, .product .price').first();
   var basePrice = parseFloat($modal.data('base-price'));
   if(isNaN(basePrice) && $priceEl.length){
-    var num = $priceEl.text().replace(/[^0-9.,]/g,'').replace(',','.');
+    var num = $priceEl.text().replace(/[^0-9,.-]/g,'').replace(',','.');
     basePrice = parseFloat(num);
   }
   if(isNaN(basePrice)) basePrice = null;
 
+  function computeExtraPrice(){
+    if(!$extraField.length) return 0;
+    var usedSides = {};
+    $canvas.children('.ws-item').each(function(){
+      usedSides[$(this).data('side')||'front'] = true;
+    });
+    var extra = 0;
+    zones.forEach(function(z){
+      var side = z.side || 'front';
+      if(usedSides[side]) extra += parseFloat(z.price || 0);
+    });
+    $extraField.val(extra.toFixed(2));
+    return extra;
+  }
+
   function updateDisplayedPrice(){
     if(basePrice===null || !$priceEl.length) return;
-    var extra = parseFloat($extraField.val()||'0');
+    var extra = computeExtraPrice();
     var total = basePrice + extra;
     var formatted = total.toLocaleString('fr-FR',{minimumFractionDigits:2,maximumFractionDigits:2});
-    $priceEl.find('.amount').first().html(formatted+'\u00a0€');
+    var $amount = $priceEl.find('.amount, bdi').first();
+    if($amount.length){
+      $amount.html(formatted+'\u00a0€');
+    }else{
+      $priceEl.text(formatted+'\u00a0€');
+    }
   }
 
   function showCustomPreview(){
@@ -331,6 +351,7 @@ jQuery(function($){
         updateItemTransform($new);
       });
     }
+    updateDisplayedPrice();
   }
 
   var gallery = $modal.data('gallery') || [];
@@ -495,10 +516,7 @@ jQuery(function($){
     $zoneButtons.find('.ws-zone-btn[data-index="'+index+'"]').addClass('active selected');
     $modal.find('.ws-print-zone').removeClass('active').hide();
     $modal.find('.ws-print-zone[data-index="'+index+'"]').show().addClass('active');
-    if($extraField.length && zones[index]){
-      $extraField.val(zones[index].price || 0);
-      updateDisplayedPrice();
-    }
+    updateDisplayedPrice();
     applyClip();
     if(activeItem){ updateDebug(activeItem); }
   }
@@ -533,8 +551,12 @@ jQuery(function($){
     var zh = $zone.height();
     var base = getBaseHeight();
     var ratio = formatHeights[fmt] || 0;
-    var h = base * ratio;
+    var h = Math.min(base * ratio, zh);
     var w = h / 1.414;
+    if(w > zw){
+      w = zw;
+      h = w * 1.414;
+    }
     var left = zpos.left + (zw - w)/2;
     var top  = zpos.top + (zh - h)/2;
     $it.css({width:w, height:h});
@@ -630,6 +652,7 @@ function openModal(){
       $('.ws-tab-content').addClass('hidden').removeClass('active');
       activeTab = 'gallery';
       showCustomPreview();
+      updateDisplayedPrice();
     }, 300);
   }
 
@@ -752,8 +775,10 @@ function openModal(){
 
 
   function addItem(type, content){
-    // Supprime l'image existante si besoin
-    if(type === 'image') $canvas.children('.ws-item[data-type="image"]').remove();
+    // Supprime l'image existante sur la même face si besoin
+    if(type === 'image') {
+      $canvas.children('.ws-item[data-type="image"][data-side="'+state.side+'"]').remove();
+    }
 
     var $item = $('<div class="ws-item" />')
       .attr('data-type', type)


### PR DESCRIPTION
## Summary
- compute the extra price by summing all used sides
- adjust `applyFormat()` so designs never stretch past the print zone
- keep price updated when loading saved state

## Testing
- `node -c assets/js/winshirt-modal.js`


------
https://chatgpt.com/codex/tasks/task_e_6879475db27c83298332139c3169290d