### PR TITLE
Implémente une refonte partielle du modal

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -78,6 +78,23 @@
   max-height: 100%;
   overflow-y: auto;
 }
+.ws-panel {
+  display:flex;
+  flex-direction:column;
+  gap:.5rem;
+  margin-bottom:1rem;
+}
+.ws-panel-btn {
+  background:rgba(255,255,255,0.1);
+  border:1px solid rgba(255,255,255,0.2);
+  padding:.5rem;
+  border-radius:.5rem;
+  color:#fff;
+  cursor:pointer;
+  text-align:left;
+}
+.ws-panel-btn:hover,
+.ws-panel-btn.active{background:rgba(255,255,255,0.2);}
 .ws-body {
   flex: 1;
   display: flex;
@@ -109,16 +126,7 @@
   background: rgba(255,255,255,0.2);
 }
 .ws-tabs-header {
-  display: flex;
-  gap: .5rem;
-  margin-bottom: 1rem;
-  border-bottom: 1px solid rgba(255,255,255,0.1);
-  padding-bottom: .5rem;
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  background: rgba(255,255,255,0.1);
-  backdrop-filter: blur(16px) saturate(180%);
+  display:none;
 }
 .ws-tab-button {
   padding: .5rem 1rem;
@@ -292,6 +300,7 @@
   color: #000;
   text-align: center;
   word-break: break-word;
+  paint-order: stroke fill;
 }
 .ws-remove {
   position: absolute;
@@ -558,6 +567,7 @@
   .ws-modal-content { flex-direction: column; }
   .ws-left, .ws-right { flex-basis: 100%; padding-right: 0; }
   .ws-right { position: static; top: auto; }
+  .ws-panel { display:none; }
 }
   .ws-tabs-header { display: none; }
   .ws-accordion-header { display: block; }

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -292,6 +292,9 @@ jQuery(function($){
         scale: parseFloat($it.attr('data-scale') || 1),
         rotation: parseInt($it.attr('data-rotation') || 0,10),
         color: $it.attr('data-color') || null,
+        align: $it.attr('data-align') || null,
+        outlineColor: $it.attr('data-outline-color') || null,
+        outlineWidth: parseInt($it.attr('data-outline-width') || 0,10),
         width: ($it.width() / $canvas.width()).toFixed(4),
         height: ($it.height() / $canvas.height()).toFixed(4),
         content: (function(){
@@ -347,6 +350,15 @@ jQuery(function($){
           } else if(it.type === 'svg'){
             $new.find('svg').css('color', it.color);
           }
+        }
+        if(it.align){
+          $new.attr('data-align', it.align);
+          $new.find('.ws-text').css('text-align', it.align);
+        }
+        if(it.outlineColor){
+          $new.attr('data-outline-color', it.outlineColor);
+          $new.attr('data-outline-width', it.outlineWidth || 0);
+          $new.find('.ws-text').css('-webkit-text-stroke', (it.outlineWidth||0)+'px '+it.outlineColor);
         }
         updateItemTransform($new);
       });
@@ -579,18 +591,26 @@ jQuery(function($){
     var italic = $('#ws-italic-btn').hasClass('active');
     var underline = $('#ws-underline-btn').hasClass('active');
     var col = $('#ws-color-picker').val() || '#000000';
+    var align = $('#ws-text-align').val() || 'center';
+    var strokeColor = $('#ws-outline-color').val() || '#000000';
+    var strokeWidth = parseInt($('#ws-outline-width').val() || 0,10);
     var scale = parseFloat($('#ws-scale-range').val() || 1);
     var rot = parseInt($('#ws-rotate-range').val() || 0,10);
     $it.attr('data-scale', scale);
     $it.attr('data-rotation', rot);
     $it.attr('data-color', col);
+    $it.attr('data-align', align);
+    $it.attr('data-outline-color', strokeColor);
+    $it.attr('data-outline-width', strokeWidth);
     var $txt = $it.find('.ws-text');
     $txt.css({
       'font-family': font,
       'font-weight': bold ? '700' : '400',
       'font-style': italic ? 'italic' : 'normal',
       'text-decoration': underline ? 'underline' : 'none',
-      'color': col
+      'color': col,
+      'text-align': align,
+      '-webkit-text-stroke': strokeWidth+'px '+strokeColor
     });
     updateItemTransform($it);
   }
@@ -637,7 +657,9 @@ function openModal(){
       if($tabSelect.length){ $tabSelect.val(tab); }
     } else {
       $('.ws-tab-button').removeClass('active');
+      $('.ws-panel-btn').removeClass('active');
       $('.ws-tab-button[data-tab="'+tab+'"]').addClass('active');
+      $('.ws-panel-btn[data-tab="'+tab+'"]').addClass('active');
       $('.ws-tab-content').addClass('hidden').removeClass('active');
       $('#ws-tab-'+tab).removeClass('hidden').addClass('active');
       if($tabSelect.length){ $tabSelect.val(tab); }
@@ -683,6 +705,12 @@ function openModal(){
   });
   $('.ws-accordion-header').on('click', function(){
     openTab($(this).data('tab'));
+  });
+  $('.ws-panel-btn[data-tab]').on('click', function(){
+    openTab($(this).data('tab'));
+  });
+  $('#ws-upload-panel').on('click', function(){
+    $('#ws-upload-trigger').trigger('click');
   });
   $('.ws-tool-btn[data-tab]').on('click', function(){
     openTab($(this).data('tab'));
@@ -762,7 +790,7 @@ function openModal(){
       saveState();
     }
   });
-  $('#ws-color-picker, #ws-scale-range, #ws-rotate-range').on('input change', function(){
+  $('#ws-color-picker, #ws-scale-range, #ws-rotate-range, #ws-text-align, #ws-outline-color, #ws-outline-width').on('input change', function(){
     if(activeItem && activeItem.data('type')==='text'){
       applyTextStyles(activeItem);
       saveState();
@@ -798,8 +826,14 @@ function openModal(){
     } else {
       $item.append('<span class="ws-text">'+content+'</span>');
       var col = $('#ws-color-picker').val() || '#000000';
-      $item.attr('data-color', col);
-      $item.find('.ws-text').css('color', col);
+      var align = $('#ws-text-align').val() || 'center';
+      var strokeColor = $('#ws-outline-color').val() || '#000000';
+      var strokeWidth = parseInt($('#ws-outline-width').val() || 0,10);
+      $item.attr('data-color', col)
+           .attr('data-align', align)
+           .attr('data-outline-color', strokeColor)
+           .attr('data-outline-width', strokeWidth);
+      $item.find('.ws-text').css({'color':col,'text-align':align,'-webkit-text-stroke':strokeWidth+'px '+strokeColor});
     }
 
     $item.append('<div class="ws-zone-resize"></div>');
@@ -954,6 +988,11 @@ function openModal(){
         if(activeItem.data('type') === 'svg'){ $('#ws-svg-color-picker').val(col); }
         $colorInput.closest('label').show();
         $removeBgBtn.addClass('hidden');
+        if(activeItem.data('type') === 'text'){
+          $('#ws-text-align').val(activeItem.attr('data-align') || 'center');
+          $('#ws-outline-color').val(activeItem.attr('data-outline-color') || '#000000');
+          $('#ws-outline-width').val(activeItem.attr('data-outline-width') || 0);
+        }
       } else {
         $colorInput.closest('label').hide();
         if(activeItem.data('type') === 'image'){

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -25,21 +25,15 @@
     </div>
 
     <div class="ws-right winshirt-theme-inherit">
-      <div class="ws-tabs-header winshirt-theme-inherit">
-        <button class="ws-tab-button active winshirt-theme-inherit" data-tab="gallery" aria-label="Galerie">🖼 Galerie</button>
-        <button class="ws-tab-button winshirt-theme-inherit" data-tab="text" aria-label="Texte">🔤 Texte</button>
-        <button class="ws-tab-button winshirt-theme-inherit" data-tab="ai" aria-label="IA">🤖 IA</button>
-        <button class="ws-tab-button winshirt-theme-inherit" data-tab="svg" aria-label="SVG">✒️ SVG</button>
+      <div class="ws-panel winshirt-theme-inherit">
+        <button class="ws-panel-btn winshirt-theme-inherit" data-tab="gallery" aria-label="Galerie">🖼 Galerie</button>
+        <button class="ws-panel-btn winshirt-theme-inherit" data-tab="text" aria-label="Texte">🔤 Texte</button>
+        <button class="ws-panel-btn winshirt-theme-inherit" data-tab="svg" aria-label="SVG">✒️ SVG</button>
+        <button class="ws-panel-btn winshirt-theme-inherit" data-tab="ai" aria-label="IA">🤖 IA</button>
+        <button class="ws-panel-btn" id="ws-upload-panel" aria-label="Upload">⬆ Uploader</button>
         <button id="ws-reset-visual" class="ws-reset winshirt-theme-inherit" aria-label="Réinitialiser">Réinitialiser ↺</button>
-        <button id="winshirt-close-modal" class="ws-close ws-ml-auto winshirt-theme-inherit" aria-label="Fermer">Fermer ✖️</button>
+        <button id="winshirt-close-modal" class="ws-close winshirt-theme-inherit" aria-label="Fermer">Fermer ✖️</button>
       </div>
-
-      <select id="ws-tab-select" class="ws-tab-select select winshirt-theme-inherit">
-        <option value="gallery">Galerie</option>
-        <option value="text">Texte</option>
-        <option value="ai">IA</option>
-        <option value="svg">SVG</option>
-      </select>
 
       <button class="ws-accordion-header winshirt-theme-inherit" data-tab="gallery" aria-label="Galerie">🖼 Galerie</button>
       <div class="ws-tab-content ws-section" id="ws-tab-gallery">
@@ -85,6 +79,17 @@
         </label>
         <label class="winshirt-theme-inherit"><?php esc_html_e('Rotation', 'winshirt'); ?>
           <input type="range" id="ws-rotate-range" class="winshirt-theme-inherit" min="0" max="360" step="1" value="0">
+        </label>
+        <label class="winshirt-theme-inherit">Alignement
+          <select id="ws-text-align" class="ws-select winshirt-theme-inherit">
+            <option value="left">Gauche</option>
+            <option value="center" selected>Centre</option>
+            <option value="right">Droite</option>
+          </select>
+        </label>
+        <label class="winshirt-theme-inherit">Contour
+          <input type="color" id="ws-outline-color" class="winshirt-theme-inherit" value="#000000" />
+          <input type="number" id="ws-outline-width" class="winshirt-theme-inherit" min="0" max="10" step="1" value="0" style="width:60px;" />
         </label>
         <button class="ws-upload-btn winshirt-theme-inherit" id="ws-add-text" aria-label="Ajouter le texte">Ajouter</button>
       </div>


### PR DESCRIPTION
## Summary
- remplace le header d'onglets par un panneau latéral vertical
- ajoute des options avancées pour le texte (alignement, contour)
- cache l'ancien header via CSS et styles dédiés
- supporte les nouvelles options côté JavaScript

## Testing
- `php -l templates/personalizer-modal.php`

------
https://chatgpt.com/codex/tasks/task_e_687a0893089883299fbc702ad6e0ebe6