### PR TITLE
Add URL field for lottery button

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -73,6 +73,7 @@ function winshirt_lottery_box_shortcode( $atts ) {
     $draw_date   = get_post_meta( $id, '_winshirt_lottery_end', true );
     $img_id      = get_post_meta( $id, '_winshirt_lottery_animation', true );
     $img_url     = $img_id ? wp_get_attachment_image_url( $img_id, 'large' ) : '';
+    $url         = get_post_meta( $id, '_winshirt_lottery_url', true );
     $percent     = $max > 0 ? min( 100, ( $count / $max ) * 100 ) : 0;
 
     ob_start();
@@ -97,7 +98,7 @@ function winshirt_lottery_box_shortcode( $atts ) {
         <?php if ( $draw_date ) : ?>
             <p class="lottery-draw"><?php echo esc_html( $draw_date ); ?></p>
         <?php endif; ?>
-        <a href="#" class="lottery-button">Participer</a>
+        <a href="<?php echo $url ? esc_url( $url ) : '#'; ?>" class="lottery-button">Participer</a>
     </div>
     <?php
     return ob_get_clean();
@@ -158,6 +159,7 @@ function winshirt_lotteries_shortcode() {
         $draw_date = get_post_meta( $id, '_winshirt_lottery_end', true );
         $img_id    = get_post_meta( $id, '_winshirt_lottery_animation', true );
         $img_url   = $img_id ? wp_get_attachment_image_url( $img_id, 'large' ) : '';
+        $url       = get_post_meta( $id, '_winshirt_lottery_url', true );
         $featured  = get_post_meta( $id, '_winshirt_lottery_featured', true ) === 'yes';
         $percent   = $max > 0 ? min( 100, ( $count / $max ) * 100 ) : 0;
 
@@ -182,7 +184,7 @@ function winshirt_lotteries_shortcode() {
             <?php if ( $draw_date ) : ?>
                 <p class="lottery-draw">Tirage le <?php echo esc_html( date_i18n( 'd/m/Y', strtotime( $draw_date ) ) ); ?></p>
             <?php endif; ?>
-            <a href="#" class="lottery-button">Participer</a>
+            <a href="<?php echo $url ? esc_url( $url ) : '#'; ?>" class="lottery-button">Participer</a>
         </div>
         <?php
     }

--- a/includes/pages/loteries.php
+++ b/includes/pages/loteries.php
@@ -44,6 +44,7 @@ function winshirt_page_lotteries() {
         update_post_meta($lottery_id, '_winshirt_lottery_active', isset($_POST['active']) ? 'yes' : 'no');
         update_post_meta($lottery_id, '_winshirt_lottery_draw', in_array($_POST['draw'] ?? 'manual', ['manual','auto'], true) ? $_POST['draw'] : 'manual');
         update_post_meta($lottery_id, 'max_participants', absint($_POST['max_participants'] ?? 0));
+        update_post_meta($lottery_id, '_winshirt_lottery_url', esc_url_raw($_POST['url'] ?? ''));
 
         if (!empty($_FILES['animation']['tmp_name'])) {
             require_once ABSPATH . 'wp-admin/includes/file.php';

--- a/templates/admin/partials/loteries-list.php
+++ b/templates/admin/partials/loteries-list.php
@@ -135,6 +135,12 @@
             </td>
         </tr>
         <tr>
+            <th scope="row"><label for="lottery-url">URL du bouton</label></th>
+            <td>
+                <input type="url" name="url" id="lottery-url" class="regular-text" value="<?php echo esc_attr(get_post_meta($editing->ID ?? 0, '_winshirt_lottery_url', true)); ?>" placeholder="https://" />
+            </td>
+        </tr>
+        <tr>
             <th scope="row"><label for="lottery-animation">Animation/Image</label></th>
             <td>
                 <input type="file" name="animation" id="lottery-animation" />


### PR DESCRIPTION
## Summary
- add admin field to set lottery link
- save the link with the lottery post
- use saved URL for lottery card buttons

## Testing
- `php -l includes/pages/loteries.php`
- `php -l templates/admin/partials/loteries-list.php`
- `php -l includes/init.php`


------
https://chatgpt.com/codex/tasks/task_e_687b5b9651208329a92c14f80631f2e4