### PR TITLE
Fix WinShirt zone persistence and add saved custo feature

### DIFF
--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -279,6 +279,25 @@ jQuery(function($){
     }
   }
 
+  function syncState(){
+    if(!winshirtAjax.loggedIn) return;
+    var data = localStorage.getItem('winshirt_custom');
+    if(!data) return;
+    fetch(winshirtAjax.rest+'save-customization', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: {
+        'X-WP-Nonce': winshirtAjax.nonce,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        data: data,
+        front: localStorage.getItem('winshirt_front_image') || '',
+        back: localStorage.getItem('winshirt_back_image') || ''
+      })
+    });
+  }
+
   checkMobile();
   if(localStorage.getItem('wsDebug')==='1'){ $debug.addClass('show'); }
   $(document).on('keydown', function(e){
@@ -321,11 +340,13 @@ jQuery(function($){
       color: state.color,
       defaultFront: $modal.data('default-front') || initialFront,
       defaultBack: $modal.data('default-back') || initialBack,
-      side: state.side
+      side: state.side,
+      zoneSel: state.zoneSel
     };
     localStorage.setItem('winshirt_custom', JSON.stringify(data));
     uploadMockup();
     updateDisplayedPrice();
+    syncState();
   }
 
   function loadState(){
@@ -335,6 +356,9 @@ jQuery(function($){
     $canvas.empty();
     if(raw.defaultFront){ $modal.data('default-front', raw.defaultFront); }
     if(raw.defaultBack){ $modal.data('default-back', raw.defaultBack); }
+    if(raw.zoneSel){
+      state.zoneSel = raw.zoneSel;
+    }
     if(raw.color){
       $('.ws-color-overlay').css('background-color', raw.color);
       state.color = raw.color;
@@ -545,6 +569,7 @@ jQuery(function($){
     updateDisplayedPrice();
     applyClip();
     if(activeItem){ updateDebug(activeItem); }
+    saveState();
   }
 
   function updateZoneButtons(){
@@ -689,6 +714,7 @@ function openModal(){
       activeTab = 'gallery';
       showCustomPreview();
       updateDisplayedPrice();
+      syncState();
     }, 300);
   }
 

--- a/includes/init.php
+++ b/includes/init.php
@@ -17,9 +17,10 @@ add_action('wp_enqueue_scripts', function () {
         wp_enqueue_script('html2canvas', 'https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js', [], '1.4.1', true);
         wp_enqueue_script('winshirt-modal', WINSHIRT_URL . 'assets/js/winshirt-modal.js', ['jquery', 'jquery-ui-draggable', 'jquery-ui-resizable', 'winshirt-touch', 'html2canvas'], '1.0', true);
         wp_localize_script('winshirt-modal', 'winshirtAjax', [
-            'url'  => admin_url('admin-ajax.php'),
-            'rest' => esc_url_raw(rest_url('winshirt/v1/')),
-            'nonce'=> wp_create_nonce('wp_rest'),
+            'url'      => admin_url('admin-ajax.php'),
+            'rest'     => esc_url_raw(rest_url('winshirt/v1/')),
+            'nonce'    => wp_create_nonce('wp_rest'),
+            'loggedIn' => is_user_logged_in(),
         ]);
 
         wp_enqueue_style('winshirt-lottery-selected', WINSHIRT_URL . 'assets/css/winshirt-lottery-selected.css', [], '1.0');
@@ -980,15 +981,18 @@ add_action( 'woocommerce_before_shop_loop_item_title', 'winshirt_shop_customizab
 add_action( 'init', 'winshirt_account_endpoint' );
 function winshirt_account_endpoint() {
     add_rewrite_endpoint( 'mes-personnalisations', EP_ROOT | EP_PAGES );
+    add_rewrite_endpoint( 'mes-custos', EP_ROOT | EP_PAGES );
 }
 
 add_filter( 'query_vars', function( $vars ) {
     $vars[] = 'mes-personnalisations';
+    $vars[] = 'mes-custos';
     return $vars;
 } );
 
 add_filter( 'woocommerce_account_menu_items', function( $items ) {
     $items['mes-personnalisations'] = __( 'Mes personnalisations', 'winshirt' );
+    $items['mes-custos'] = __( 'Mes Custos', 'winshirt' );
     return $items;
 } );
 
@@ -1018,5 +1022,29 @@ function winshirt_account_customs_page() {
             }
             echo '</div>';
         }
+    }
+}
+
+add_action( 'woocommerce_account_mes-custos_endpoint', 'winshirt_account_custos_drafts_page' );
+function winshirt_account_custos_drafts_page() {
+    $saved = get_user_meta( get_current_user_id(), 'winshirt_saved_customs', true );
+    if ( ! is_array( $saved ) ) {
+        echo '<p>' . esc_html__( 'Aucune personnalisation sauvegardée.', 'winshirt' ) . '</p>';
+        return;
+    }
+    echo '<h3>' . esc_html__( 'Mes Custos', 'winshirt' ) . '</h3>';
+    foreach ( array_reverse( $saved ) as $custo ) {
+        $front = isset( $custo['front'] ) ? esc_url( $custo['front'] ) : '';
+        $back  = isset( $custo['back'] ) ? esc_url( $custo['back'] ) : '';
+        echo '<div style="margin-bottom:1rem;">';
+        if ( $front ) {
+            echo '<img src="' . $front . '" style="max-width:150px;height:auto;border:1px solid #ccc;" />';
+            echo '<br/><a href="' . $front . '" download>' . esc_html__( 'Télécharger', 'winshirt' ) . '</a>';
+        }
+        if ( $back ) {
+            echo '<br/><img src="' . $back . '" style="max-width:150px;height:auto;border:1px solid #ccc;" />';
+            echo '<br/><a href="' . $back . '" download>' . esc_html__( 'Télécharger', 'winshirt' ) . '</a>';
+        }
+        echo '</div>';
     }
 }


### PR DESCRIPTION
## Summary
- persist zone selection in `winshirt_custom` state
- sync customization state to server for logged in users
- add REST route and account page to manage saved "Mes Custos"
- localize `loggedIn` flag for JS

## Testing
- `php -l includes/init.php`
- `php -l includes/rest.php`
- `php -l winshirt.php`

------
https://chatgpt.com/codex/tasks/task_e_687c935e0ee48329b221db4293f3dd18