### PR TITLE
Throttle mockup upload to improve canvas UX

### DIFF
--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -36,6 +36,8 @@ jQuery(function($){
   }
   if(isNaN(basePrice)) basePrice = null;
 
+  var saveTimeout = null;
+
   function computeExtraPrice(){
     if(!$extraField.length) return 0;
     var used = {front:false, back:false};
@@ -344,9 +346,12 @@ jQuery(function($){
       zoneSel: state.zoneSel
     };
     localStorage.setItem('winshirt_custom', JSON.stringify(data));
-    uploadMockup();
     updateDisplayedPrice();
-    syncState();
+    if(saveTimeout){ clearTimeout(saveTimeout); }
+    saveTimeout = setTimeout(function(){
+      uploadMockup();
+      syncState();
+    }, 500);
   }
 
   function loadState(){


### PR DESCRIPTION
## Summary
- prevent constant mockup uploads when editing items
- schedule `uploadMockup`/`syncState` with a 500 ms delay

## Testing
- `php -l winshirt.php`
- `find includes -name '*.php' -print0 | xargs -0 -I {} php -l {}`
- `php -l uninstall.php`
- `php -l winshirt_ia_generate.php`

------
https://chatgpt.com/codex/tasks/task_e_687c9f90f2b883299fe1d725cc1a3f02