### PR TITLE
Fix capture and unify customizations

### DIFF
--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -178,14 +178,14 @@ jQuery(function($){
     return new Promise(function(resolve){
       if(!window.html2canvas){ resolve(); return; }
       var prev = state.side;
-      $modal.find('.ws-preview').css('visibility','hidden');
+      var $hidden = $modal.find('.ws-print-zone, .ws-zone-label, .ws-zone-resize, .ws-remove');
+      $hidden.css('visibility','hidden');
       if(side!==prev) switchSide(side);
-      html2canvas($modal.find('.ws-preview')[0], {backgroundColor:null,scale:1}).then(function(canvas){
+      html2canvas($modal.find('.ws-preview')[0], {backgroundColor:null,scale:1,useCORS:true,allowTaint:true}).then(function(canvas){
+        $hidden.css('visibility','');
         canvas.toBlob(function(blob){
           if(!blob){
             if(side!==prev) switchSide(prev);
-
-            $modal.find('.ws-preview').css('visibility','');
             resolve();
             return;
           }
@@ -206,7 +206,6 @@ jQuery(function($){
               }
             }
             if(side!==prev) switchSide(prev);
-            $modal.find('.ws-preview').css('visibility','');
             resolve();
           });
         }, 'image/png');

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -16,7 +16,7 @@
         <button id="winshirt-back-btn" class="ws-side-btn winshirt-theme-inherit" aria-label="Verso">Verso</button>
       </div>
       <div class="ws-preview mockup-fixed ws-section winshirt-theme-inherit">
-        <img src="<?php echo esc_url( $default_front ?? '' ); ?>" alt="Mockup" class="ws-preview-img" />
+        <img src="<?php echo esc_url( $default_front ?? '' ); ?>" alt="Mockup" class="ws-preview-img" crossorigin="anonymous" />
         <div class="ws-color-overlay winshirt-theme-inherit"></div>
         <div id="ws-canvas" class="ws-canvas"></div>
         <div id="ws-print-zones"></div>


### PR DESCRIPTION
## Summary
- improve capture workflow by not hiding preview during screenshot
- load modal on account page and merge saved customizations
- drop `mes-custos` endpoint
- allow resuming from saved captures
- ensure images use CORS

## Testing
- `php -l includes/init.php`
- `php -l templates/personalizer-modal.php`


------
https://chatgpt.com/codex/tasks/task_e_687ca3228ba483298ca64d0999dda708