### PR TITLE
Improve customization management

### DIFF
--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -294,7 +294,8 @@ jQuery(function($){
       body: JSON.stringify({
         data: data,
         front: localStorage.getItem('winshirt_front_image') || '',
-        back: localStorage.getItem('winshirt_back_image') || ''
+        back: localStorage.getItem('winshirt_back_image') || '',
+        product: parseInt($modal.data('product-id') || 0)
       })
     });
   }
@@ -349,7 +350,6 @@ jQuery(function($){
     if(saveTimeout){ clearTimeout(saveTimeout); }
     saveTimeout = setTimeout(function(){
       uploadMockup();
-      syncState();
     }, 500);
   }
 
@@ -718,7 +718,6 @@ function openModal(){
       activeTab = 'gallery';
       showCustomPreview();
       updateDisplayedPrice();
-      syncState();
     }, 300);
   }
 
@@ -1200,6 +1199,7 @@ function openModal(){
     if($customField.length){ $customField.val(json); }
     console.log('WinShirt data', JSON.stringify(items));
     saveState();
+    syncState();
     captureAllSides().then(function(){
       if(window.dataLayer){ dataLayer.push({event:'customize_completed', product_id:$modal.data('product-id')}); }
       closeModal();
@@ -1215,4 +1215,8 @@ function openModal(){
 
   switchSide('front');
   openTab('gallery');
+  if(localStorage.getItem('winshirt_resume') === '1'){
+    localStorage.removeItem('winshirt_resume');
+    openModal();
+  }
 });

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -137,8 +137,9 @@ function winshirt_rest_save_customization( WP_REST_Request $request ) {
         return new WP_REST_Response( [ 'message' => 'no_data' ], 400 );
     }
 
-    $front = esc_url_raw( $request->get_param( 'front' ) );
-    $back  = esc_url_raw( $request->get_param( 'back' ) );
+    $front   = esc_url_raw( $request->get_param( 'front' ) );
+    $back    = esc_url_raw( $request->get_param( 'back' ) );
+    $product = absint( $request->get_param( 'product' ) );
 
     $user_id = get_current_user_id();
     $saved   = get_user_meta( $user_id, 'winshirt_saved_customs', true );
@@ -151,11 +152,39 @@ function winshirt_rest_save_customization( WP_REST_Request $request ) {
         'data'  => wp_unslash( $data ),
         'front' => $front,
         'back'  => $back,
+        'product' => $product,
     ];
 
     update_user_meta( $user_id, 'winshirt_saved_customs', $saved );
 
     return new WP_REST_Response( [ 'status' => 'ok' ], 200 );
+}
+
+/**
+ * Delete a saved customization by index for logged in users.
+ */
+function winshirt_rest_delete_customization( WP_REST_Request $request ) {
+    if ( ! is_user_logged_in() ) {
+        return new WP_REST_Response( [ 'message' => 'forbidden' ], 403 );
+    }
+
+    $index = $request->get_param( 'index' );
+    if ( null === $index ) {
+        $json  = $request->get_json_params();
+        $index = $json['index'] ?? null;
+    }
+    $index   = intval( $index );
+
+    $user_id = get_current_user_id();
+    $saved   = get_user_meta( $user_id, 'winshirt_saved_customs', true );
+    if ( ! is_array( $saved ) || ! isset( $saved[ $index ] ) ) {
+        return new WP_REST_Response( [ 'message' => 'not_found' ], 404 );
+    }
+
+    array_splice( $saved, $index, 1 );
+    update_user_meta( $user_id, 'winshirt_saved_customs', $saved );
+
+    return new WP_REST_Response( [ 'status' => 'deleted' ], 200 );
 }
 
 add_action( 'rest_api_init', function() {
@@ -180,6 +209,12 @@ add_action( 'rest_api_init', function() {
     register_rest_route( 'winshirt/v1', '/save-customization', [
         'methods'             => WP_REST_Server::CREATABLE,
         'callback'            => 'winshirt_rest_save_customization',
+        'permission_callback' => '__return_true',
+    ] );
+
+    register_rest_route( 'winshirt/v1', '/delete-customization', [
+        'methods'             => WP_REST_Server::DELETABLE,
+        'callback'            => 'winshirt_rest_delete_customization',
         'permission_callback' => '__return_true',
     ] );
 });


### PR DESCRIPTION
## Summary
- keep track of the product when saving a customization
- allow removing saved customizations and resume on correct product page
- avoid duplicate saves and auto–open customizer when resuming
- fix resume visibility and deletion handler

## Testing
- `php -l includes/rest.php`
- `php -l includes/init.php`


------
https://chatgpt.com/codex/tasks/task_e_687ca7ce9d6883299bd29826b99f1dfb