### PR TITLE
Fix customization deletion code

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -1090,9 +1090,6 @@ function winshirt_account_customs_page() {
             })
             .then(function(r){ return r.json(); })
             .then(function(){ location.reload(); });
-
-            }).then(function(){ location.reload(); });
- main
         });
     });
     </script>

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -175,9 +175,6 @@ function winshirt_rest_delete_customization( WP_REST_Request $request ) {
     }
     $index   = intval( $index );
 
-
-    $index   = intval( $request->get_param( 'index' ) );
-main
     $user_id = get_current_user_id();
     $saved   = get_user_meta( $user_id, 'winshirt_saved_customs', true );
     if ( ! is_array( $saved ) || ! isset( $saved[ $index ] ) ) {


### PR DESCRIPTION
## Summary
- clean up stray code in account page JS
- remove duplicate lines in REST deletion endpoint

## Testing
- `php -l includes/init.php`
- `php -l includes/rest.php`


------
https://chatgpt.com/codex/tasks/task_e_687cb42c25e48329a90a2cf32331ca6c