### PR TITLE
Improve mobile usability

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -51,6 +51,7 @@
   padding: 0.75rem;
   border-bottom: 1px solid #eee;
   margin-bottom: 0.5rem;
+  background: #fff;
 }
 
 .ws-left {
@@ -149,6 +150,7 @@
 }
 .ws-tab-content {
   display: none;
+  background: #fff;
   animation: wsFade .3s ease;
 }
 .ws-tab-content.active {
@@ -552,6 +554,7 @@
     left: 0;
     right: 0;
     bottom: 0;
+    background: #fff;
     max-height: 60vh;
     overflow-y: auto;
     border-top-left-radius: 1rem;
@@ -855,7 +858,7 @@
 .ws-mobile .ws-preview {
   margin-top:0;
   width:100%;
-  max-height:calc(100dvh - 150px);
+  max-height:calc(100dvh - 90px);
 }
 .ws-mobile .ws-toggle {
   justify-content:center;

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -259,7 +259,7 @@ jQuery(function($){
     if(!$modal.hasClass('ws-mobile')) return;
     var toolsH = $modal.find('.ws-tools').outerHeight() || 0;
     var toggleH = $modal.find('.ws-toggle').outerHeight() || 0;
-    var offset = toolsH + toggleH + 32; // padding/margins
+    var offset = toolsH + toggleH + 16; // padding/margins reduced
     var max = window.innerHeight - offset;
     $modal.find('.ws-preview').css('max-height', max + 'px');
   }
@@ -856,13 +856,19 @@ function openModal(){
       $canvas.children('.ws-item[data-type="image"][data-side="'+state.side+'"]').remove();
     }
 
+    var $zone = $(getContainment());
+    var zoneW = $zone.width();
+    var zoneH = $zone.height();
+    var initSize = Math.min(zoneW, zoneH) * 0.5;
+    if(!initSize || isNaN(initSize)) initSize = 120;
+
     var $item = $('<div class="ws-item" />')
       .attr('data-type', type)
       .attr('data-side', state.side)
       .attr('data-scale','1')
       .attr('data-rotation','0')
       .attr('data-x','0').attr('data-y','0')
-      .css({width:120, height:120, left:0, top:0});
+      .css({width:initSize, height:initSize, left:0, top:0});
 
     if(type === 'image'){
       $item.append('<img src="'+content+'" alt="" style="width:100%;height:100%;pointer-events:none;"/>');
@@ -889,10 +895,7 @@ function openModal(){
     $canvas.append($item);
 
     // Centre dans la zone d'impression
-    var $zone = $(getContainment());
     var zonePos = $zone.position();
-    var zoneW = $zone.width();
-    var zoneH = $zone.height();
     var itemW = $item.width();
     var itemH = $item.height();
     $item.attr('data-x', zonePos.left + (zoneW - itemW)/2)


### PR DESCRIPTION
## Summary
- enlarge mobile preview height and panel backgrounds
- set white background for mobile tabs and sections
- start new items at half the print zone size

## Testing
- `php -l winshirt.php`


------
https://chatgpt.com/codex/tasks/task_e_687ce521c1c48329990e31fc5cd90091