### PR TITLE
Improve mobile modal layout

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -273,13 +273,15 @@
   pointer-events: auto;
 }
 .ws-item .ui-resizable-handle {
-  width: 8px;
-  height: 8px;
+  width: 16px;
+  height: 16px;
+  border: 2px solid #fff;
+  background: #000;
   border-radius: 50%;
-  background: #e5e5e5;
-  border: 1px solid #ccc;
+  box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
   position: absolute;
   display: none;
+  touch-action: none;
 }
 .ws-item .ui-resizable-nw { cursor: nwse-resize; }
 .ws-item .ui-resizable-ne { cursor: nesw-resize; }
@@ -623,11 +625,13 @@
 .ws-debug.show { display: block; }
 .ui-resizable-handle {
   position: absolute;
-  width: 12px;
-  height: 12px;
-  background: #fff;
-  border: 1px solid #000;
+  width: 16px;
+  height: 16px;
+  border: 2px solid #fff;
+  background: #000;
   border-radius: 50%;
+  box-shadow: 0 0 3px rgba(0,0,0,0.3);
+  touch-action: none;
 }
 .ui-resizable-nw { left: -6px; top: -6px; cursor: nw-resize; }
 .ui-resizable-ne { right: -6px; top: -6px; cursor: ne-resize; }
@@ -696,15 +700,17 @@
 /* Poign\xC3\xA9es de resize */
 .ws-zone-resize, .admin-zone-resize {
   position: absolute;
-  width: 18px;
-  height: 18px;
-  background: #fff;
-  border: 2px solid #52a3ff;
+  width: 16px;
+  height: 16px;
+  border: 2px solid #fff;
+  background: #000;
   border-radius: 50%;
+  box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
   cursor: nwse-resize;
-  right: -9px;
-  bottom: -9px;
-  z-index: 15;
+  right: -8px;
+  bottom: -8px;
+  z-index: 20;
+  touch-action: none;
 }
 
 .ws-item, .admin-mockup-item {
@@ -858,11 +864,19 @@
 .ws-mobile .ws-preview {
   margin-top: 0;
   width: 100%;
-  max-height: calc(100dvh - 90px);
+  max-height: calc(100dvh - 100px);
   display: flex;
   align-items: center;
   justify-content: center;
   position: relative;
+}
+.ws-mobile .ws-sides-toggle {
+  margin-bottom: 0.5rem;
+  padding-top: 0;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  z-index: 5;
 }
 .ws-mobile .ws-toggle {
   justify-content: center;
@@ -877,8 +891,8 @@
   position: absolute;
   top: 0;
   width: 100%;
-  background: #fff;
-  z-index: 10;
+  background-color: #fff !important;
+  z-index: 20;
   border-radius: 1rem;
   box-shadow: 0 4px 12px rgba(0,0,0,0.1);
   padding: 1rem;
@@ -891,6 +905,21 @@
 }
 
 .ws-item {
-  padding: 10px;
+  padding: 6px;
   box-sizing: content-box;
+}
+
+.draggable-element .resize-handle {
+  width: 16px;
+  height: 16px;
+  border: 2px solid #fff;
+  background: #000;
+  border-radius: 50%;
+  box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
+  z-index: 20;
+  touch-action: none;
+}
+
+.draggable-element {
+  padding: 6px;
 }

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -258,7 +258,7 @@ jQuery(function($){
   function updatePreviewHeight(){
     if(!$modal.hasClass('ws-mobile')) return;
     var toolsH = $modal.find('.ws-tools').outerHeight() || 0;
-    var toggleH = $modal.find('.ws-toggle').outerHeight() || 0;
+    var toggleH = $modal.find('.ws-sides-toggle').outerHeight() || 0;
     var offset = toolsH + toggleH + 16; // padding/margins reduced
     var max = window.innerHeight - offset;
     $modal.find('.ws-preview').css('max-height', max + 'px');
@@ -745,7 +745,7 @@ function openModal(){
 
   window.addEventListener('resize', () => {
     const preview = document.querySelector('.ws-preview');
-    const footer = document.querySelector('.ws-toggle');
+    const footer = document.querySelector('.ws-sides-toggle');
     const headerHeight = 40; // boutons recto/verso
     const footerHeight = footer?.offsetHeight || 90;
     const availableHeight = window.innerHeight - headerHeight - footerHeight;

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -11,7 +11,7 @@
   <div class="ws-modal-content winshirt-theme-inherit">
 
     <div class="ws-left winshirt-theme-inherit">
-      <div class="ws-toggle winshirt-theme-inherit" style="margin-bottom:.5rem;">
+      <div class="ws-toggle ws-sides-toggle winshirt-theme-inherit">
         <button id="winshirt-front-btn" class="ws-side-btn active winshirt-theme-inherit" aria-label="Recto">Recto</button>
         <button id="winshirt-back-btn" class="ws-side-btn winshirt-theme-inherit" aria-label="Verso">Verso</button>
       </div>


### PR DESCRIPTION
## Summary
- update mobile preview height
- adjust sides toggle styling and z-index
- force white panel backgrounds
- shrink resize handles and selection padding
- ensure JS uses the new sides toggle class

## Testing
- `php -l templates/personalizer-modal.php`

------
https://chatgpt.com/codex/tasks/task_e_687d084e32b0832983c8d581677a6c63