### PR TITLE
Ajuste du modal mobile

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -17,13 +17,13 @@
 .ws-modal-content {
   position: relative;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
+  justify-content: space-between;
   align-items: flex-start;
-  justify-content: center;
   width: 95%;
-  height: 95%;
+  height: 100dvh;
   max-width: 95vw;
-  max-height: 95vh;
+  max-height: 100dvh;
   background: #fff;
   border: 1px solid #ccc;
   border-radius: 8px;
@@ -244,6 +244,11 @@
   transform: none;
   margin-top: 0;
 }
+
+.ws-mobile .mockup-fixed {
+  max-height: unset !important;
+  height: auto !important;
+}
 .ws-preview-img {
   max-width: 90%;
   max-height: 100%;
@@ -351,11 +356,14 @@
 }
 
 .ws-zone-buttons {
+  position: absolute;
+  bottom: 1rem;
+  left: 0;
+  right: 0;
   display: flex;
-  flex-wrap: wrap;
   justify-content: center;
-  gap: 10px;
-  margin-top: .5rem;
+  gap: 0.5rem;
+  z-index: 10;
 }
 .ws-zone-btn {
   background: #f5f5f5;
@@ -458,9 +466,6 @@
   display: block;
 }
 
-@media(max-width:768px){
-  .ws-zone-buttons { justify-content:center; }
-}
 #ws-print-zones {
   position: absolute;
   inset: 0;
@@ -862,21 +867,34 @@
   align-items:center;
 }
 .ws-mobile .ws-preview {
-  margin-top: 0;
-  width: 100%;
-  max-height: calc(100dvh - 100px);
+  flex-grow: 1;
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 0;
+  margin: 0;
+  height: auto !important;
+  max-height: unset !important;
+  width: 100%;
   position: relative;
 }
-.ws-mobile .ws-sides-toggle {
-  margin-bottom: 0.5rem;
-  padding-top: 0;
+
+.ws-mobile .tshirt-container {
+  width: auto;
+  max-height: 100%;
+  max-width: 100%;
+  display: block;
+  object-fit: contain;
+}
+.ws-sides-toggle {
+  position: absolute;
+  top: 0.5rem;
+  left: 0;
+  right: 0;
   display: flex;
   justify-content: center;
   gap: 1rem;
-  z-index: 5;
+  z-index: 10;
 }
 .ws-mobile .ws-toggle {
   justify-content: center;

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -256,12 +256,7 @@ jQuery(function($){
   }
 
   function updatePreviewHeight(){
-    if(!$modal.hasClass('ws-mobile')) return;
-    var toolsH = $modal.find('.ws-tools').outerHeight() || 0;
-    var toggleH = $modal.find('.ws-sides-toggle').outerHeight() || 0;
-    var offset = toolsH + toggleH + 16; // padding/margins reduced
-    var max = window.innerHeight - offset;
-    $modal.find('.ws-preview').css('max-height', max + 'px');
+    $modal.find('.ws-preview').css('max-height', '');
   }
 
   function debugHiddenElements(){
@@ -743,14 +738,7 @@ function openModal(){
     updatePreviewHeight();
   });
 
-  window.addEventListener('resize', () => {
-    const preview = document.querySelector('.ws-preview');
-    const footer = document.querySelector('.ws-sides-toggle');
-    const headerHeight = 40; // boutons recto/verso
-    const footerHeight = footer?.offsetHeight || 90;
-    const availableHeight = window.innerHeight - headerHeight - footerHeight;
-    if (preview) preview.style.maxHeight = `${availableHeight}px`;
-  });
+
 
   $('.ws-tab-button').on('click', function(){
     openTab($(this).data('tab'));


### PR DESCRIPTION
## Résumé
- ajuste `ws-modal-content` pour remplir toute la hauteur et utiliser Flexbox
- retire les restrictions de taille sur `.ws-preview`
- positionne les boutons Recto/Verso et zone en absolu
- enlève la gestion JS de la `max-height` du preview

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d4465af1c8329a00037e569c41821