### PR TITLE
Fix modal desktop layout and add close button

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -17,13 +17,13 @@
 .ws-modal-content {
   position: relative;
   display: flex;
-  flex-direction: column;
-  justify-content: space-between;
+  flex-direction: row;
   align-items: flex-start;
+  justify-content: center;
   width: 95%;
-  height: 100dvh;
+  height: 95%;
   max-width: 95vw;
-  max-height: 100dvh;
+  max-height: 95vh;
   background: #fff;
   border: 1px solid #ccc;
   border-radius: 8px;
@@ -38,6 +38,49 @@
 .ws-modal.open .ws-modal-content {
   transform: none;
   opacity: 1;
+}
+
+/* --- Ajout croix fermer haut gauche --- */
+.ws-modal-close-btn {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  z-index: 1001;
+  width: 32px;
+  height: 32px;
+  background: #fff;
+  border: 1.5px solid #ccc;
+  border-radius: 50%;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.09);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+.ws-modal-close-btn:hover {
+  background: #ffe5e5;
+  box-shadow: 0 2px 12px rgba(255,0,0,0.10);
+}
+.ws-modal-close-btn svg {
+  width: 18px;
+  height: 18px;
+  stroke: #d32f2f;
+  stroke-width: 2.2;
+  fill: none;
+  pointer-events: none;
+}
+@media (max-width: 700px) {
+  .ws-modal-close-btn {
+    top: 10px;
+    left: 10px;
+    width: 28px;
+    height: 28px;
+  }
+  .ws-modal-close-btn svg {
+    width: 15px;
+    height: 15px;
+  }
 }
 
 .ws-modal-content input,

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -719,6 +719,7 @@ function openModal(){
   // Ouvre la modale depuis le bouton de personnalisation
   $('#btn-personnaliser').on('click', function(e){ e.preventDefault(); openModal(); });
   $('#winshirt-close-modal').on('click', closeModal);
+  $('.ws-modal-close-btn').on('click', closeModal);
   $('#ws-reset-visual').on('click', function(){
     $canvas.children('.ws-item[data-type="image"]').remove();
     $modal.data('default-front', initialFront);

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -9,6 +9,9 @@
   data-base-price="<?php echo esc_attr( $product instanceof WC_Product ? $product->get_price() : 0 ); ?>">
   
   <div class="ws-modal-content winshirt-theme-inherit">
+    <button type="button" class="ws-modal-close-btn" aria-label="Fermer">
+      <svg viewBox="0 0 24 24"><line x1="4" y1="4" x2="20" y2="20"/><line x1="20" y1="4" x2="4" y2="20"/></svg>
+    </button>
 
     <div class="ws-left winshirt-theme-inherit">
       <div class="ws-toggle ws-sides-toggle winshirt-theme-inherit">


### PR DESCRIPTION
## Summary
- restore row layout for `.ws-modal-content` on desktop
- add close button markup and styles
- wire close button click handler

## Testing
- `php -l templates/personalizer-modal.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687de3361e608329b4c8fb6a86647b9a