### PR TITLE
Fix desktop modal layout and enlarge mobile preview

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -17,12 +17,12 @@
 .ws-modal-content {
   position: relative;
   display: flex;
-  flex-direction: column;
-  justify-content: space-between;
+  flex-direction: row;
   align-items: flex-start;
-  width: 98%;
+  justify-content: center;
+  width: 95%;
   height: 100dvh;
-  max-width: 98vw;
+  max-width: 95vw;
   max-height: 100dvh;
   background: #fff;
   border: 1px solid #ccc;
@@ -264,7 +264,7 @@
 .ws-preview {
   position: relative;
   margin-top: 1.5rem;
-  width: 100%;
+  width: 90%;
   aspect-ratio: 4 / 5;
   background: #f5f5f5;
   border: 1px solid #ccc;
@@ -286,7 +286,7 @@
   height: auto !important;
 }
 .ws-preview-img {
-  max-width: 100%;
+  max-width: 90%;
   max-height: 100%;
   object-fit: contain;
 }
@@ -303,3 +303,11 @@
   width: 100%;
   height: 100%;
 }
+
+/* Responsive layout for mobile */
+.ws-mobile .ws-modal-content { flex-direction: column; }
+.ws-mobile .ws-left,
+.ws-mobile .ws-right { flex-basis: 100%; padding-right: 0; }
+.ws-mobile .ws-right { position: static; }
+.ws-mobile .ws-preview { width: 100%; }
+.ws-mobile .ws-preview-img { max-width: 100%; }


### PR DESCRIPTION
## Summary
- restore side-by-side layout for desktop modals
- keep preview width at 90% on desktop
- grow preview area when `.ws-mobile` is active

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e64a6e3188329aa9e09ad4f66023d