### PR TITLE
Streamline modal controls

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -163,25 +163,6 @@
 .ws-reset:hover {
   background: #e5e5e5;
 }
-.ws-tabs-header {
-  display:none;
-}
-.ws-tab-button {
-  padding: .5rem 1rem;
-  border-radius: .5rem;
-  background: #f5f5f5;
-  border: 1px solid #ccc;
-  cursor: pointer;
-  transition: background .3s;
-  font-size: 1rem;
-  font-weight: 600;
-  color: #000;
-}
-.ws-tab-button:hover,
-.ws-tab-button.active {
-  background: #e5e5e5;
-  box-shadow: 0 0 0 2px #ccc;
-}
 .ws-ml-auto {
   margin-left: auto;
 }

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -676,39 +676,18 @@ function openModal(){
   };
 
   function openTab(tab){
-    if($modal.hasClass('ws-mobile')){
-      var $c = $('#ws-tab-'+tab);
-      var $h = $('.ws-accordion-header[data-tab="'+tab+'"]');
-      if(activeTab === tab && $c.hasClass('active')){
-        $c.addClass('hidden').removeClass('active');
-        $h.removeClass('open');
-        $modal.find('.ws-right').removeClass('show');
-        activeTab = null;
-        return;
-      }
-      activeTab = tab;
-      $('.ws-accordion-header').removeClass('open');
-      $('.ws-tab-content').addClass('hidden').removeClass('active');
-      $h.addClass('open');
-      $c.removeClass('hidden').addClass('active');
-      $modal.find('.ws-right').addClass('show');
-      if($tabSelect.length){ $tabSelect.val(tab); }
-    } else {
-      $('.ws-tab-button').removeClass('active');
-      $('.ws-panel-btn').removeClass('active');
-      $('.ws-tab-button[data-tab="'+tab+'"]').addClass('active');
-      $('.ws-panel-btn[data-tab="'+tab+'"]').addClass('active');
-      $('.ws-tab-content').addClass('hidden').removeClass('active');
-      $('#ws-tab-'+tab).removeClass('hidden').addClass('active');
-      if($tabSelect.length){ $tabSelect.val(tab); }
-    }
+    activeTab = tab;
+    $('.ws-panel-btn').removeClass('active');
+    $('.ws-panel-btn[data-tab="'+tab+'"]').addClass('active');
+    $('.ws-tab-content').addClass('hidden').removeClass('active');
+    $('#ws-tab-'+tab).removeClass('hidden').addClass('active');
+    if($tabSelect.length){ $tabSelect.val(tab); }
   }
   function closeModal(){
     $modal.removeClass('open');
     setTimeout(function(){
       $modal.addClass('hidden');
       $modal.find('.ws-right').removeClass('show');
-      $('.ws-accordion-header').removeClass('open');
       $('.ws-tab-content').addClass('hidden').removeClass('active');
       activeTab = 'gallery';
       showCustomPreview();
@@ -741,22 +720,11 @@ function openModal(){
 
 
 
-  $('.ws-tab-button').on('click', function(){
-    openTab($(this).data('tab'));
-  });
-  $('.ws-accordion-header').on('click', function(){
-    openTab($(this).data('tab'));
-  });
+  // Interaction principale : clic sur les boutons du panneau latéral
   $('.ws-panel-btn[data-tab]').on('click', function(){
     openTab($(this).data('tab'));
   });
   $('#ws-upload-panel').on('click', function(){
-    $('#ws-upload-trigger').trigger('click');
-  });
-  $('.ws-tool-btn[data-tab]').on('click', function(){
-    openTab($(this).data('tab'));
-  });
-  $('#ws-upload-tool').on('click', function(){
     $('#ws-upload-trigger').trigger('click');
   });
   $tabSelect.on('change', function(){

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -38,7 +38,6 @@
         <button id="winshirt-close-modal" class="ws-close winshirt-theme-inherit" aria-label="Fermer">Fermer ✖️</button>
       </div>
 
-      <button class="ws-accordion-header winshirt-theme-inherit" data-tab="gallery" aria-label="Galerie">🖼 Galerie</button>
       <div class="ws-tab-content ws-section" id="ws-tab-gallery">
         <p>Choisissez un design dans la galerie.</p>
         <div class="ws-gallery-cats winshirt-theme-inherit"></div>
@@ -47,7 +46,6 @@
         <input type="file" id="ws-upload-input" accept="image/*" class="hidden winshirt-theme-inherit" />
       </div>
 
-      <button class="ws-accordion-header winshirt-theme-inherit" data-tab="text" aria-label="Texte">🔤 Texte</button>
       <div class="ws-tab-content ws-section hidden" id="ws-tab-text">
         <input type="text" id="ws-text-content" class="ws-input input-text winshirt-theme-inherit" placeholder="Votre texte..." />
         <select id="ws-font-select" class="ws-select select winshirt-theme-inherit">
@@ -97,7 +95,6 @@
         <button class="ws-upload-btn winshirt-theme-inherit" id="ws-add-text" aria-label="Ajouter le texte">Ajouter</button>
       </div>
 
-      <button class="ws-accordion-header winshirt-theme-inherit" data-tab="ai" aria-label="IA">🤖 IA</button>
       <div class="ws-tab-content ws-section hidden" id="ws-tab-ai">
         <div class="ws-ai-form winshirt-theme-inherit">
           <input type="text" id="ws-ai-prompt" class="ws-input input-text winshirt-theme-inherit" placeholder="Décris le visuel que tu veux créer" />
@@ -107,7 +104,6 @@
         <div id="ws-ai-gallery" class="ws-ai-gallery winshirt-theme-inherit"></div>
       </div>
 
-      <button class="ws-accordion-header winshirt-theme-inherit" data-tab="svg" aria-label="SVG">✒️ SVG</button>
       <div class="ws-tab-content ws-section hidden" id="ws-tab-svg">
         <p>Bibliothèque d’icônes vectorielles (SVG).</p>
         <button id="ws-svg-upload-trigger" class="ws-upload-btn winshirt-theme-inherit" aria-label="Uploader un SVG">Uploader un SVG</button>
@@ -156,12 +152,5 @@
 
     </div>
   <div id="ws-debug" class="ws-debug"></div>
-  <div class="ws-tools winshirt-theme-inherit">
-    <button class="ws-tool-btn" data-tab="gallery" aria-label="Galerie">📷</button>
-    <button class="ws-tool-btn" id="ws-upload-tool" aria-label="Uploader">⬆</button>
-    <button class="ws-tool-btn" data-tab="ai" aria-label="IA">🤖</button>
-    <button class="ws-tool-btn" data-tab="text" aria-label="Texte">✏</button>
-    <button class="ws-tool-btn" data-tab="svg" aria-label="SVG">📄</button>
-  </div>
 </div>
 </div>


### PR DESCRIPTION
## Summary
- keep only sidebar buttons for switching sections
- drop legacy tab and accordion controls
- clean up unused CSS

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_687e6a8394f4832992f40d208589c607