### PR TITLE
Fix print zone visibility

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -15,6 +15,7 @@ add_action('wp_enqueue_scripts', function () {
         wp_enqueue_style('winshirt-modal', WINSHIRT_URL . 'assets/css/winshirt-modal.css', [], '1.0');
         wp_enqueue_style('winshirt-lottery', WINSHIRT_URL . 'assets/css/winshirt-lottery.css', [], '1.0');
         wp_enqueue_style('winshirt-theme', WINSHIRT_URL . 'assets/css/winshirt-theme.css', [], '1.0');
+        wp_enqueue_style('winshirt-mockups', WINSHIRT_URL . 'assets/css/winshirt-mockups.css', [], '1.0');
 
         wp_enqueue_script('winshirt-touch', WINSHIRT_URL . 'assets/js/jquery.ui.touch-punch.min.js', ['jquery', 'jquery-ui-mouse'], '0.2.3', true);
         wp_enqueue_script('html2canvas', 'https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js', [], '1.4.1', true);


### PR DESCRIPTION
## Summary
- ensure mockup styles load on product pages so print zones are visible

## Testing
- `php -l includes/init.php`


------
https://chatgpt.com/codex/tasks/task_e_687f32fe4bec8329af01017774ddff73