### PR TITLE
Improve simple modal design

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -292,3 +292,49 @@
 .ws-mobile .ws-right { position: static; }
 .ws-mobile .ws-preview { width: 100%; }
 .ws-mobile .ws-preview-img { max-width: 100%; }
+
+/* --- Basic modal template styles --- */
+#winshirt-modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,0.6);
+  z-index: 9999;
+}
+#winshirt-modal.open { display: flex; }
+#winshirt-modal .winshirt-modal-content {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1rem;
+  width: 90%;
+  max-width: 600px;
+  box-shadow: 0 0 20px rgba(0,0,0,0.2);
+  position: relative;
+}
+#winshirt-modal .winshirt-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  font-size: 24px;
+  cursor: pointer;
+}
+#winshirt-modal .winshirt-buttons {
+  display: flex;
+  gap: .5rem;
+  margin-bottom: 1rem;
+}
+#winshirt-modal .winshirt-btn {
+  background: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: .25rem .5rem;
+  cursor: pointer;
+}
+#winshirt-modal .winshirt-btn.active,
+#winshirt-modal .winshirt-btn:hover {
+  background: #e5e5e5;
+}
+#winshirt-modal .winshirt-tab { display: none; }
+#winshirt-modal .winshirt-tab.active { display: block; }

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -1196,3 +1196,23 @@ function openModal(){
     openModal();
   }
 });
+
+jQuery(function($){
+  var $basic = $('#winshirt-modal');
+  if(!$basic.length) return;
+
+  function showSection(id){
+    $basic.find('.winshirt-tab').removeClass('active');
+    $basic.find('#'+id).addClass('active');
+    $basic.find('.winshirt-btn').removeClass('active');
+    $basic.find('.winshirt-btn[data-target="'+id+'"]').addClass('active');
+  }
+
+  $basic.on('click', '.winshirt-btn', function(e){
+    e.preventDefault();
+    showSection($(this).data('target'));
+  });
+
+  var first = $basic.find('.winshirt-btn').first().data('target');
+  if(first){ showSection(first); }
+});

--- a/templates/frontend/modal-personnalisation.php
+++ b/templates/frontend/modal-personnalisation.php
@@ -1,12 +1,12 @@
 <div id="winshirt-modal" class="winshirt-modal" data-default-front="<?php echo esc_attr( $default_front ?? '' ); ?>" data-default-back="<?php echo esc_attr( $default_back ?? '' ); ?>">
   <div class="winshirt-modal-content">
     <span class="winshirt-close">&times;</span>
-    <ul class="winshirt-tab-links">
-      <li class="active"><a href="#winshirt-tab-galerie">🖼 Galerie</a></li>
-      <li><a href="#winshirt-tab-texte">🔤 Texte</a></li>
-      <li><a href="#winshirt-tab-ia">🤖 IA</a></li>
-      <li><a href="#winshirt-tab-svg">🖌️ SVG</a></li>
-    </ul>
+    <div class="winshirt-buttons">
+      <button type="button" class="winshirt-btn active" data-target="winshirt-tab-galerie">🖼 Galerie</button>
+      <button type="button" class="winshirt-btn" data-target="winshirt-tab-texte">🔤 Texte</button>
+      <button type="button" class="winshirt-btn" data-target="winshirt-tab-ia">🤖 IA</button>
+      <button type="button" class="winshirt-btn" data-target="winshirt-tab-svg">🖌️ SVG</button>
+    </div>
     <div class="winshirt-tab" id="winshirt-tab-galerie">
       <button class="winshirt-upload button alt">Uploader un visuel</button>
       <input type="file" class="winshirt-upload-input" style="display:none" accept="image/*" />


### PR DESCRIPTION
## Summary
- replace tab navigation with buttons in `modal-personnalisation.php`
- add modern styles for the basic modal layout
- add small JS helper for switching sections

## Testing
- `php -l templates/frontend/modal-personnalisation.php`

------
https://chatgpt.com/codex/tasks/task_e_687f3c1bece48329b971a7e7ae500bb9