### PR TITLE
Refactor customizer modal layout

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -17,11 +17,10 @@
 .ws-modal-content {
   position: relative;
   display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  justify-content: center;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
   width: 95%;
-  height: 100dvh;
   max-width: 95vw;
   max-height: 100dvh;
   background: #fff;
@@ -43,7 +42,7 @@
 .ws-modal-close-btn {
   position: absolute;
   top: 16px;
-  left: 16px;
+  right: 16px;
   z-index: 1001;
   width: 32px;
   height: 32px;
@@ -72,7 +71,7 @@
 @media (max-width: 700px) {
   .ws-modal-close-btn {
     top: 10px;
-    left: 10px;
+    right: 10px;
     width: 28px;
     height: 28px;
   }
@@ -93,7 +92,7 @@
   background: #fff;
 }
 .ws-left {
-  flex-basis: 75%;
+  flex-basis: 70%;
   padding-right: 1rem;
   box-sizing: border-box;
   position: sticky;
@@ -107,13 +106,51 @@
   justify-content: center;
 }
 .ws-right {
-  flex-basis: 25%;
+  flex-basis: 30%;
   position: sticky;
   top: 0;
   display: flex;
   flex-direction: column;
   max-height: 100%;
   overflow-y: auto;
+}
+
+.modal__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+}
+
+.modal__header,
+.modal__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .5rem;
+}
+
+.modal__content {
+  flex: 1;
+  display: flex;
+  gap: 1rem;
+  overflow: hidden;
+}
+
+.modal__mockup-area { flex-basis: 70%; padding-right: 1rem; box-sizing: border-box; }
+.modal__sidebar { flex-basis: 30%; overflow-y: auto; }
+
+.side-btn {
+  background: #fff;
+  border: 1px solid #000;
+  padding: .25rem .75rem;
+  border-radius: .375rem;
+  cursor: pointer;
+  transition: background .2s, color .2s;
+}
+.side-btn:hover,
+.side-btn.active {
+  background: #000;
+  color: #fff;
 }
 .ws-panel {
   display:flex;
@@ -122,16 +159,20 @@
   margin-bottom:1rem;
 }
 .ws-panel-btn {
-  background:#f5f5f5;
-  border:1px solid #ccc;
+  background:#fff;
+  border:1px solid #000;
   padding:.5rem;
   border-radius:.5rem;
   color:#000;
   cursor:pointer;
   text-align:left;
+  transition:background .2s,color .2s;
 }
 .ws-panel-btn:hover,
-.ws-panel-btn.active{background:#e5e5e5;}
+.ws-panel-btn.active{
+  background:#000;
+  color:#fff;
+}
 .ws-body {
   flex: 1;
   display: flex;
@@ -141,27 +182,30 @@
   min-height: 0;
 }
 .ws-close {
-  background: #f5f5f5;
+  background: #fff;
   padding: .25rem .75rem;
-  border: 1px solid #ccc;
+  border: 1px solid #000;
   border-radius: .375rem;
   cursor: pointer;
-  transition: background .2s;
+  transition: background .2s,color .2s;
   color: #000;
 }
 .ws-close:hover {
-  background: #e5e5e5;
+  background: #000;
+  color: #fff;
 }
 .ws-reset {
-  background: #f5f5f5;
+  background: #fff;
   padding: .25rem .75rem;
-  border: 1px solid #ccc;
+  border: 1px solid #000;
   border-radius: .375rem;
   cursor: pointer;
-  transition: background .2s;
+  transition: background .2s,color .2s;
+  color: #000;
 }
 .ws-reset:hover {
-  background: #e5e5e5;
+  background: #000;
+  color: #fff;
 }
 .ws-ml-auto {
   margin-left: auto;
@@ -189,14 +233,29 @@
 .ws-upload-btn {
   margin-top: 1rem;
   padding: .5rem 1rem;
-  background: #f5f5f5;
-  border: 1px solid #ccc;
+  background: #fff;
+  border: 1px solid #000;
   border-radius: .5rem;
   color: #000;
   cursor: pointer;
+  transition: background .2s,color .2s;
 }
 .ws-upload-btn:hover {
-  background: #e5e5e5;
+  background: #000;
+  color: #fff;
+}
+.ws-validate {
+  background: #fff;
+  border: 1px solid #000;
+  padding: .25rem .75rem;
+  border-radius: .375rem;
+  cursor: pointer;
+  transition: background .2s,color .2s;
+  color: #000;
+}
+.ws-validate:hover {
+  background: #000;
+  color: #fff;
 }
 .ws-gallery-cats {
   display: flex;
@@ -206,16 +265,17 @@
 }
 .ws-cat-btn {
   padding: .25rem .75rem;
-  background: #f5f5f5;
-  border: 1px solid #ccc;
+  background: #fff;
+  border: 1px solid #000;
   border-radius: .375rem;
   color: #000;
   cursor: pointer;
-  transition: background .2s;
+  transition: background .2s,color .2s;
 }
 .ws-cat-btn.active,
 .ws-cat-btn:hover {
-  background: #e5e5e5;
+  background: #000;
+  color: #fff;
 }
 .ws-gallery {
   display: grid;

--- a/templates/personalizer-modal.php
+++ b/templates/personalizer-modal.php
@@ -1,4 +1,4 @@
-<div id="winshirt-customizer-modal" class="ws-modal hidden winshirt-theme-inherit"
+<div id="winshirt-customizer-modal" class="ws-modal hidden winshirt-theme-inherit modal"
   data-default-front="<?php echo esc_attr( $default_front ?? '' ); ?>"
   data-default-back="<?php echo esc_attr( $default_back ?? '' ); ?>"
   data-colors='<?php echo esc_attr( $ws_colors ?? '[]' ); ?>'
@@ -7,17 +7,22 @@
   data-ai-gallery='<?php echo esc_attr( $ws_ai_gallery ?? '[]' ); ?>'
   data-product-id="<?php echo esc_attr( $pid ); ?>"
   data-base-price="<?php echo esc_attr( $product instanceof WC_Product ? $product->get_price() : 0 ); ?>">
-  
-  <div class="ws-modal-content winshirt-theme-inherit">
-    <button type="button" class="ws-modal-close-btn" aria-label="Fermer">
-      <svg viewBox="0 0 24 24"><line x1="4" y1="4" x2="20" y2="20"/><line x1="20" y1="4" x2="4" y2="20"/></svg>
-    </button>
 
-    <div class="ws-left winshirt-theme-inherit">
-      <div class="ws-toggle ws-sides-toggle winshirt-theme-inherit">
-        <button id="winshirt-front-btn" class="ws-side-btn active winshirt-theme-inherit" aria-label="Recto">Recto</button>
-        <button id="winshirt-back-btn" class="ws-side-btn winshirt-theme-inherit" aria-label="Verso">Verso</button>
+  <div class="modal__overlay"></div>
+  <div class="ws-modal-content winshirt-theme-inherit modal__container">
+    <div class="modal__header">
+      <div class="ws-toggle ws-sides-toggle winshirt-theme-inherit modal__side-switch">
+        <button id="winshirt-front-btn" class="ws-side-btn active winshirt-theme-inherit side-btn" aria-label="Recto">Recto</button>
+        <button id="winshirt-back-btn" class="ws-side-btn winshirt-theme-inherit side-btn" aria-label="Verso">Verso</button>
       </div>
+      <div class="ws-colors winshirt-theme-inherit modal__color-picker"></div>
+      <button type="button" class="ws-modal-close-btn modal__close" aria-label="Fermer">
+        <svg viewBox="0 0 24 24"><line x1="4" y1="4" x2="20" y2="20"/><line x1="20" y1="4" x2="4" y2="20"/></svg>
+      </button>
+    </div>
+
+    <div class="modal__content">
+      <div class="ws-left winshirt-theme-inherit modal__mockup-area">
       <div class="ws-preview mockup-fixed ws-section winshirt-theme-inherit">
         <img src="<?php echo esc_url( $default_front ?? '' ); ?>" alt="Mockup" class="ws-preview-img" crossorigin="anonymous" />
         <div class="ws-color-overlay winshirt-theme-inherit"></div>
@@ -34,8 +39,6 @@
         <button class="ws-panel-btn winshirt-theme-inherit" data-tab="svg" aria-label="SVG">✒️ SVG</button>
         <button class="ws-panel-btn winshirt-theme-inherit" data-tab="ai" aria-label="IA">🤖 IA</button>
         <button class="ws-panel-btn" id="ws-upload-panel" aria-label="Upload">⬆ Uploader</button>
-        <button id="ws-reset-visual" class="ws-reset winshirt-theme-inherit" aria-label="Réinitialiser">Réinitialiser ↺</button>
-        <button id="winshirt-close-modal" class="ws-close winshirt-theme-inherit" aria-label="Fermer">Fermer ✖️</button>
       </div>
 
       <div class="ws-tab-content ws-section" id="ws-tab-gallery">
@@ -138,19 +141,22 @@
         </div>
       </div>
 
-      <div class="ws-colors winshirt-theme-inherit"></div>
       <input type="hidden" id="winshirt-custom-data" value="" />
       <input type="hidden" id="winshirt-production-image" value="" />
       <input type="hidden" id="winshirt-front-image" value="" />
-      <input type="hidden" id="winshirt-back-image" value="" />
+        <input type="hidden" id="winshirt-back-image" value="" />
 
-        <div class="ws-actions ws-section winshirt-theme-inherit">
-          <small class="ws-size-note">Taille réelle estimée sur un visuel 1500x1500px – affichage à titre indicatif.</small>
-          <button id="btn-valider-personnalisation" class="ws-validate winshirt-theme-inherit" aria-label="Valider la personnalisation">Valider la personnalisation</button>
-          <button id="btn-test-capture" class="ws-validate winshirt-theme-inherit" aria-label="Test capture">Test Capture</button>
-        </div>
+      </div>
 
+    </div> <!-- end modal__content -->
+
+    <div class="ws-actions ws-section winshirt-theme-inherit modal__footer">
+      <small class="ws-size-note">Taille réelle estimée sur un visuel 1500x1500px – affichage à titre indicatif.</small>
+      <button id="ws-reset-visual" class="ws-reset winshirt-theme-inherit modal__reset" aria-label="Réinitialiser">Réinitialiser ↺</button>
+      <button id="btn-valider-personnalisation" class="ws-validate winshirt-theme-inherit modal__save" aria-label="Valider la personnalisation">Valider la personnalisation</button>
+      <button id="btn-test-capture" class="ws-validate winshirt-theme-inherit" aria-label="Test capture">Test Capture</button>
     </div>
-  <div id="ws-debug" class="ws-debug"></div>
-</div>
+
+    <div id="ws-debug" class="ws-debug"></div>
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- restructure personalizer modal markup for header/sidebar/footer layout
- modernize modal styles with outline buttons and responsive header

## Testing
- `php -l templates/personalizer-modal.php`

------
https://chatgpt.com/codex/tasks/task_e_687f4b968f708329b15aad7e56d947c9