### PR TITLE
Fix customizer assets with shortcode

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -6,7 +6,8 @@ add_action('wp_enqueue_scripts', function () {
     global $post;
     $needs_assets = is_product();
     if ( ! $needs_assets && isset( $post->post_content ) ) {
-        $needs_assets = has_shortcode( $post->post_content, 'product_page' );
+        $needs_assets = has_shortcode( $post->post_content, 'product_page' ) ||
+            has_shortcode( $post->post_content, 'winshirt_customizer' );
     }
     if ( ! $needs_assets && function_exists( 'is_account_page' ) && is_account_page() && is_wc_endpoint_url( 'mes-personnalisations' ) ) {
         $needs_assets = true;

--- a/readme.txt
+++ b/readme.txt
@@ -27,6 +27,7 @@ Une page "Loteries" permet de créer et d'administrer les tirages. Chaque loteri
 * `[loterie_box id="123" vedette="true"]` – carte individuelle de loterie avec tous les détails.
 * `[winshirt_lotteries]` – liste de toutes les loteries sous forme de cartes.
 * `[loterie_thumb id="123"]` – uniquement l'image miniature.
+* `[winshirt_customizer]` – bouton de personnalisation avec chargement automatique des scripts.
 
 ## Ouverture du modale via JavaScript
 Ajoutez un bouton personnalisé et appelez la fonction suivante pour afficher la personnalisation :


### PR DESCRIPTION
## Summary
- enqueue modal assets when the `[winshirt_customizer]` shortcode is used
- document the shortcode in the readme

## Testing
- `php -l includes/init.php`
- `php -l winshirt.php`


------
https://chatgpt.com/codex/tasks/task_e_687f55acaf8c8329a9230c3d9ed05715