### PR TITLE
Fix customizer modal trigger

### DIFF
--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -1,6 +1,9 @@
 jQuery(function($){
   var $modal = $('#winshirt-customizer-modal');
-  if(!$modal.length) return;
+  if(!$modal.length){
+    console.error('WinShirt: modal #winshirt-customizer-modal not found');
+    return;
+  }
   $('body').append($modal);
   var state = { side: 'front', color: null, zone: 0, zoneSel: { front: 0, back: 0 } };
   var $canvas = $('#ws-canvas');
@@ -660,7 +663,7 @@ function openModal(){
   loadAiImages();
   renderAiGallery();
   if(state.color){ $('.ws-color-overlay').css('background-color', state.color); }
-  $modal.removeClass('hidden').addClass('open');
+  $modal.removeClass('hidden').addClass('open active');
   if (!$modal.hasClass('ws-mobile')) {
     setTimeout(function(){ $modal.find('.ws-right').addClass('show'); }, 10);
   }
@@ -684,7 +687,7 @@ function openModal(){
     if($tabSelect.length){ $tabSelect.val(tab); }
   }
   function closeModal(){
-    $modal.removeClass('open');
+    $modal.removeClass('open active');
     setTimeout(function(){
       $modal.addClass('hidden');
       $modal.find('.ws-right').removeClass('show');
@@ -696,7 +699,17 @@ function openModal(){
   }
 
   // Ouvre la modale depuis le bouton de personnalisation
-  $('#btn-personnaliser').on('click', function(e){ e.preventDefault(); openModal(); });
+  // utilise la délégation pour prendre en compte les boutons ajoutés dynamiquement
+  var $openBtn = $('.btn-personnaliser, #btn-personnaliser');
+  if(!$openBtn.length){
+    console.error('WinShirt: bouton de personnalisation introuvable');
+  }
+  $(document).on('click', '.btn-personnaliser, #btn-personnaliser', function(e){
+    e.preventDefault();
+    try{ openModal(); }catch(err){
+      console.error('WinShirt: ouverture du modal impossible', err);
+    }
+  });
   $('#winshirt-close-modal').on('click', closeModal);
   $('.ws-modal-close-btn').on('click', closeModal);
   $('#ws-reset-visual').on('click', function(){

--- a/includes/init.php
+++ b/includes/init.php
@@ -324,7 +324,7 @@ function winshirt_render_customize_button() {
 
     // Bouton d\xE9clenchant la personnalisation sur la fiche produit
     // Utilise les mêmes classes que le bouton "Ajouter au panier" pour hériter du style du thème
-    echo '<div class="winshirt-personnaliser-btn"><button id="btn-personnaliser" class="single_add_to_cart_button button alt glow-on-hover">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button></div>';
+    echo '<div class="winshirt-personnaliser-btn"><button id="btn-personnaliser" class="single_add_to_cart_button button alt glow-on-hover btn-personnaliser">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button></div>';
     $default_front = $front_url;
     $default_back  = $back_url;
     $ws_colors     = wp_json_encode( $colors );


### PR DESCRIPTION
## Summary
- use delegated click handler for `.btn-personnaliser`
- retain console error logging

## Testing
- `php -l includes/init.php`
- `node -e "require('fs').readFileSync('assets/js/winshirt-modal.js'); console.log('js ok')"`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f591a97e48329bcc9b41acf5867e2