### PR TITLE
Fix mobile modal trigger

### DIFF
--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -701,7 +701,10 @@ function openModal(){
 // WinShirt: ouverture du modal de personnalisation
 
 // Délégation d’événement = fonctionne même si le bouton est injecté après coup
-$(document).on('click', '.btn-personnaliser, #btn-personnaliser', function(e){
+// Sur certains thémès mobiles, l'événement "click" peut ne pas se déclencher
+// correctement. On écoute également "touchstart" pour garantir l'ouverture du
+// modal sur tous les navigateurs mobiles.
+$(document).on('click touchstart', '.btn-personnaliser, #btn-personnaliser', function(e){
   e.preventDefault();
   try {
     openModal();


### PR DESCRIPTION
## Summary
- fix customizer modal open handler

## Testing
- `php -l` *(fails: `php: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_687fb72c97108329be52e28b4cb66e1d