### PR TITLE
Fix WinShirt modal init when markup loads later

### DIFF
--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -1,8 +1,9 @@
 jQuery(function($){
+  function init(){
   var $modal = $('#winshirt-customizer-modal');
   if(!$modal.length){
     console.error('WinShirt: modal #winshirt-customizer-modal not found');
-    return;
+    return false;
   }
   $('body').append($modal);
   var state = { side: 'front', color: null, zone: 0, zoneSel: { front: 0, back: 0 } };
@@ -718,7 +719,6 @@ if (!$('.btn-personnaliser, #btn-personnaliser').length) {
   console.warn('WinShirt: bouton de personnalisation introuvable au DOMContentLoaded');
 }
 
-  });
   $('#winshirt-close-modal').on('click', closeModal);
   $('.ws-modal-close-btn').on('click', closeModal);
   $('#ws-reset-visual').on('click', function(){
@@ -1210,15 +1210,20 @@ if (!$('.btn-personnaliser, #btn-personnaliser').length) {
       alert('Capture enregistrée');
     });
   });
-
   switchSide('front');
   openTab('gallery');
   if(localStorage.getItem('winshirt_resume') === '1'){
     localStorage.removeItem('winshirt_resume');
     openModal();
   }
-});
+  return true;
+}
 
+  if(!init()){
+    var observer = new MutationObserver(function(){ if(init()){ observer.disconnect(); } });
+    observer.observe(document.body,{childList:true,subtree:true});
+  }
+});
 jQuery(function($){
   var $basic = $('#winshirt-modal');
   if(!$basic.length) return;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: shakass
 Tags: woocommerce, personnalisation, t-shirt, loterie
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.0.4
+Stable tag: 1.0.5
 License: GPLv2 or later
 
 Plugin pour personnalisation de produits et loteries via WooCommerce.

--- a/winshirt.php
+++ b/winshirt.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WinShirt by Shakass
  * Description: Module de personnalisation produit et loteries pour WooCommerce.
- * Version: 1.0.4
+ * Version: 1.0.5
  * Author: Shakass Communication
  */
 


### PR DESCRIPTION
## Summary
- fix initialization of the product customization modal
- bump plugin version to 1.0.5

## Testing
- `node -c assets/js/winshirt-modal.js`

------
https://chatgpt.com/codex/tasks/task_e_687fbc374a70832983def27f07376753