### PR TITLE
Add visual category dropdown

### DIFF
--- a/templates/admin/partials/visuels-list.php
+++ b/templates/admin/partials/visuels-list.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Admin visual management interface.
- * Variables: $visuals, $filters
+ * Variables: $visuals, $filters, $categories
  */
 ?>
 <form method="get" style="margin-bottom:15px;">
@@ -72,8 +72,19 @@
             <td><input type="file" name="file" id="visual-file" required /></td>
         </tr>
         <tr>
-            <th scope="row"><label for="visual-category"><?php esc_html_e('Catégorie', 'winshirt'); ?></label></th>
-            <td><input type="text" name="category" id="visual-category" /></td>
+            <th scope="row"><label for="visual-category-select"><?php esc_html_e('Catégorie', 'winshirt'); ?></label></th>
+            <td>
+                <select name="category_select" id="visual-category-select">
+                    <option value=""><?php esc_html_e('Choisir', 'winshirt'); ?></option>
+                    <?php foreach ($categories as $cat) : ?>
+                        <option value="<?php echo esc_attr($cat); ?>"><?php echo esc_html($cat); ?></option>
+                    <?php endforeach; ?>
+                </select>
+                <p style="margin-top:6px;">
+                    <label for="visual-category-new"><?php esc_html_e('Ou créer une nouvelle', 'winshirt'); ?>:</label>
+                    <input type="text" name="category_new" id="visual-category-new" />
+                </p>
+            </td>
         </tr>
     </table>
     <p><input type="submit" class="button button-primary" value="<?php esc_attr_e('Uploader', 'winshirt'); ?>" /></p>


### PR DESCRIPTION
## Summary
- add helper to gather all visual categories
- update visual creation form with dropdown and new category field

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68834ea074d48329be57bcfa15e6cd69