### PR TITLE
Implement data-pid buttons with vanilla JS handler

### DIFF
--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -1,3 +1,17 @@
+// Déclencheur universel pour ouvrir le modal WinShirt
+document.addEventListener('click', function(e) {
+  const btn = e.target.closest('.btn-personnaliser');
+  if(btn) {
+    const pid = btn.getAttribute('data-pid');
+    if(window.openWinShirtModal) {
+      openWinShirtModal(pid);
+    } else {
+      alert("Erreur : la personnalisation n'est pas disponible pour le moment.");
+    }
+    e.preventDefault();
+  }
+});
+
 jQuery(function($){
   function init(){
   var $modal = $('#winshirt-customizer-modal');
@@ -699,27 +713,7 @@ function openModal(){
     }, 300);
   }
 
-// WinShirt: ouverture du modal de personnalisation
 
-// Délégation d’événement = fonctionne même si le bouton est injecté après coup
-// Sur certains thémès mobiles, l'événement "click" peut ne pas se déclencher
-// correctement. On écoute également "touchstart" pour garantir l'ouverture du
-// modal sur tous les navigateurs mobiles.
-$(document).on('click touchstart', '.btn-personnaliser, #btn-personnaliser', function(e){
-  e.preventDefault();
-  e.stopPropagation();
-  if (e.stopImmediatePropagation) e.stopImmediatePropagation();
-  try {
-    openModal();
-  } catch(err) {
-    console.error('WinShirt: ouverture du modal impossible', err);
-  }
-});
-
-// Debug visuel (optionnel) : log si bouton absent au DOM load
-if (!$('.btn-personnaliser, #btn-personnaliser').length) {
-  console.warn('WinShirt: bouton de personnalisation introuvable au DOMContentLoaded');
-}
 
   $('#winshirt-close-modal').on('click', closeModal);
   $('.ws-modal-close-btn').on('click', closeModal);

--- a/includes/init.php
+++ b/includes/init.php
@@ -325,7 +325,7 @@ function winshirt_render_customize_button() {
 
     // Bouton d\xE9clenchant la personnalisation sur la fiche produit
     // Utilise les mêmes classes que le bouton "Ajouter au panier" pour hériter du style du thème
-    echo '<div class="winshirt-personnaliser-btn"><button id="btn-personnaliser" class="single_add_to_cart_button button alt glow-on-hover btn-personnaliser" onclick="if(window.openWinShirtModal){openWinShirtModal(' . $pid . ');}return false;">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button></div>';
+    echo '<div class="winshirt-personnaliser-btn">\n  <button class="single_add_to_cart_button button alt glow-on-hover btn-personnaliser" data-pid="' . esc_attr( $pid ) . '">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button>\n</div>';
     $default_front = $front_url;
     $default_back  = $back_url;
     $ws_colors     = wp_json_encode( $colors );

--- a/readme.txt
+++ b/readme.txt
@@ -30,8 +30,8 @@ Une page "Loteries" permet de créer et d'administrer les tirages. Chaque loteri
 * `[winshirt_customizer]` – bouton de personnalisation avec chargement automatique des scripts.
 
 ## Ouverture du modale via JavaScript
-Ajoutez un bouton personnalisé et appelez la fonction suivante pour afficher la personnalisation :
+Ajoutez un bouton personnalisé comportant l'attribut `data-pid` ; le déclenchement se fait automatiquement :
 
 ```
-<button onclick="openWinShirtModal(123)">Personnaliser</button>
+<button class="btn-personnaliser" data-pid="123">Personnaliser</button>
 ```


### PR DESCRIPTION
## Summary
- generate personalization button without IDs using `data-pid`
- trigger the modal with a global vanilla JS listener
- document the new button usage in the README

## Testing
- `php -l includes/init.php`
- `node --check assets/js/winshirt-modal.js`


------
https://chatgpt.com/codex/tasks/task_e_6883579c71308329b8250db5124168e6