### PR TITLE
Fix modal button event handling

### DIFF
--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -1,14 +1,17 @@
 // Déclencheur universel pour ouvrir le modal WinShirt
+// Gestion robuste du bouton "Personnaliser ce produit"
 document.addEventListener('click', function(e) {
-  const btn = e.target.closest('.btn-personnaliser');
-  if(btn) {
-    const pid = btn.getAttribute('data-pid');
-    if(window.openWinShirtModal) {
-      openWinShirtModal(pid);
+  var btn = e.target.closest('.btn-personnaliser');
+  if (btn) {
+    var pid = btn.getAttribute('data-pid');
+    console.log("Bouton personnaliser cliqué, pid=", pid, "openWinShirtModal=", typeof window.openWinShirtModal);
+    if (typeof window.openWinShirtModal === "function") {
+      window.openWinShirtModal(pid);
     } else {
-      alert("Erreur : la personnalisation n'est pas disponible pour le moment.");
+      alert("La personnalisation n'est pas disponible pour le moment.");
     }
     e.preventDefault();
+    return false;
   }
 });
 
@@ -284,7 +287,8 @@ jQuery(function($){
       if(!$el.is(':visible')){
         var desc = this.tagName.toLowerCase();
         if(this.id) desc += '#' + this.id;
-        if(this.className) desc += '.' + this.className.trim().replace(/\s+/g,'.');
+        var cls = this.getAttribute('class');
+        if(cls) desc += '.' + cls.trim().replace(/\s+/g,'.');
         hidden.push(desc);
       }
     });


### PR DESCRIPTION
## Summary
- improve click handler for `.btn-personnaliser` button so events are caught even when clicking nested elements
- add temporary debug logging to help with debugging
- avoid `.className.trim` errors on SVG elements by using `getAttribute('class')`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68835a3510988329b61acc962fbb3fa6