### PR TITLE
Fix customize button markup and confirm JS loading

### DIFF
--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -1,5 +1,6 @@
 // Déclencheur universel pour ouvrir le modal WinShirt
 // Gestion robuste du bouton "Personnaliser ce produit"
+console.log('JS du bouton personnalisation chargé');
 document.addEventListener('click', function(e) {
   var btn = e.target.closest('.btn-personnaliser');
   if (btn) {

--- a/includes/init.php
+++ b/includes/init.php
@@ -325,7 +325,7 @@ function winshirt_render_customize_button() {
 
     // Bouton d\xE9clenchant la personnalisation sur la fiche produit
     // Utilise les mêmes classes que le bouton "Ajouter au panier" pour hériter du style du thème
-    echo '<div class="winshirt-personnaliser-btn">\n  <button class="single_add_to_cart_button button alt glow-on-hover btn-personnaliser" data-pid="' . esc_attr( $pid ) . '">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button>\n</div>';
+    echo '<div class="winshirt-personnaliser-btn"><button class="single_add_to_cart_button button alt glow-on-hover btn-personnaliser" data-pid="' . esc_attr( $pid ) . '">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button></div>';
     $default_front = $front_url;
     $default_back  = $back_url;
     $ws_colors     = wp_json_encode( $colors );


### PR DESCRIPTION
## Summary
- remove newline characters from personalize button HTML
- log JS script loading

## Testing
- `php -l includes/init.php`
- `node -e "console.log('node works')"`


------
https://chatgpt.com/codex/tasks/task_e_68835bcfc2cc8329ab3f2f5eca0844c9