### PR TITLE
Add product selector and open customizer

### DIFF
--- a/templates/customizer-page.php
+++ b/templates/customizer-page.php
@@ -10,12 +10,41 @@ $featured_products = get_posts([
   'meta_query'     => [['key' => '_visibility', 'value' => 'visible']],
 ]);
 
+// Liste complète des produits personnalisables
+$available_products = wc_get_products([
+  'limit'     => -1,
+  'status'    => 'publish',
+  'orderby'   => 'title',
+  'order'     => 'ASC',
+  'meta_query' => [
+    [
+      'key'   => '_winshirt_enabled',
+      'value' => 'yes',
+    ],
+  ],
+]);
+$selectable_products = [];
+foreach ( $available_products as $ap ) {
+  if ( winshirt_get_customizer_vars( $ap->get_id() ) ) {
+    $selectable_products[] = $ap;
+  }
+}
+
 $page_id = absint( get_option( 'winshirt_custom_page' ) );
 $customizer_page_url = $page_id ? get_permalink( $page_id ) : '/personnalisez/';
 
 // Layout principal
 ?>
 <div class="winshirt-customizer-container">
+  <div class="winshirt-product-selector">
+    <label for="ws-product-select">Produit :</label>
+    <select id="ws-product-select" class="ws-select">
+      <option value="">-- <?php esc_html_e( 'Sélectionner', 'winshirt' ); ?> --</option>
+      <?php foreach ( $selectable_products as $sp ) : ?>
+        <option value="<?php echo esc_attr( $sp->get_id() ); ?>" <?php selected( $product && $product->get_id() === $sp->get_id() ); ?>><?php echo esc_html( $sp->get_name() ); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
   <?php if ( empty($product) ) : ?>
     <div class="winshirt-no-product">
       <h2>Choisissez un produit à personnaliser</h2>
@@ -41,12 +70,22 @@ $customizer_page_url = $page_id ? get_permalink( $page_id ) : '/personnalisez/';
         <a href="<?php echo esc_url( get_permalink( wc_get_page_id('shop') ) ); ?>" class="winshirt-btn winshirt-btn-small">Changer de produit</a>
       </header>
       <section class="winshirt-customizer-workspace">
-        <!-- Ici, le code principal de ton customizer (mockup, panels, options) -->
-        <?php
-        // Par exemple :
-        // winshirt_render_customizer($product, $colors, $zones, ...);
-        ?>
+        <?php include WINSHIRT_PATH . 'templates/personalizer-modal.php'; ?>
       </section>
+      <script type="text/javascript">
+      document.addEventListener('DOMContentLoaded', function(){
+        if (typeof window.openWinShirtModal === 'function') {
+          window.openWinShirtModal(<?php echo intval( $product->get_id() ); ?>);
+        }
+      });
+      </script>
     </main>
   <?php endif; ?>
 </div>
+<script type="text/javascript">
+document.getElementById('ws-product-select').addEventListener('change', function(){
+  if(this.value){
+    window.location.href = '<?php echo esc_url( $customizer_page_url ); ?>?product_id=' + this.value;
+  }
+});
+</script>


### PR DESCRIPTION
## Summary
- add dropdown with all customizable products on the customizer page
- automatically open the personalizer modal when a product is chosen
- provide JS to change the page when selecting a product

## Testing
- `php -l templates/customizer-page.php`
- `php -l templates/personalizer-modal.php`
- `php -l includes/init.php`


------
https://chatgpt.com/codex/tasks/task_e_68848dcafb748329a21e86dc10bbb8f1