### PR TITLE
Add Next-Gen customization page

### DIFF
--- a/assets/css/winshirt-nextgen.css
+++ b/assets/css/winshirt-nextgen.css
@@ -1,0 +1,201 @@
+:root {
+  --ws-bg: #f7f7fa;
+  --ws-main: #fff;
+  --ws-accent: #02b7f0;
+  --ws-grey: #ccc;
+  --ws-btn: #232b2b;
+  --ws-btn-active: #02b7f0;
+  --ws-shadow: 0 2px 16px 0 #0002;
+}
+
+body {
+  background: var(--ws-bg);
+  margin: 0;
+  font-family: 'Inter', Arial, sans-serif;
+}
+
+/* Wrapper principal */
+.ws-configurator {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Header */
+.ws-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--ws-main);
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--ws-grey);
+}
+.ws-logo { font-weight: 800; font-size: 1.2rem; color: var(--ws-accent);} 
+.ws-nav-btn {
+  background: none; border: none; font-size: 1.6rem; margin: 0 0.2rem; cursor: pointer;
+  transition: color .2s;
+}
+.ws-nav-btn:focus, .ws-nav-btn:hover { color: var(--ws-accent); outline: none; }
+
+/* Main area */
+.ws-main {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  background: var(--ws-bg);
+}
+.ws-sidebar, .ws-rightbar {
+  display: none;
+}
+@media (min-width: 900px) {
+  .ws-sidebar, .ws-rightbar {
+    display: flex; flex-direction: column; gap: .6rem; background: var(--ws-main);
+    min-width: 60px; width: 60px; border-right: 1px solid var(--ws-grey); padding-top: 1rem;
+  }
+}
+
+/* Design area */
+.ws-design-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  min-height: 0;
+  background: var(--ws-main);
+  padding: 0;
+  position: relative;
+}
+
+.ws-face-switcher {
+  display: flex;
+  gap: 1rem;
+  margin: 1rem 0 0.3rem 0;
+  z-index: 2;
+}
+.ws-face-btn {
+  background: #fff; border: 2px solid var(--ws-accent); color: var(--ws-accent);
+  border-radius: 18px; padding: .4rem 1.2rem; font-size: 1rem; font-weight: 600;
+  box-shadow: var(--ws-shadow);
+  cursor: pointer;
+  transition: background .2s, color .2s;
+}
+.ws-face-btn.active,
+.ws-face-btn:focus { background: var(--ws-accent); color: #fff; outline: none; }
+
+/* Preview produit (t-shirt géant) */
+.ws-product-preview {
+  position: relative;
+  width: 98vw;
+  max-width: 480px;
+  height: 58vw;
+  max-height: 74vh;
+  margin: 0 auto;
+  background: #fff;
+  display: flex;
+  align-items: center; justify-content: center;
+  border-radius: 18px;
+  box-shadow: var(--ws-shadow);
+  overflow: hidden;
+  touch-action: none;
+}
+
+.ws-mockup-img {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: 74vh;
+  object-fit: contain;
+  pointer-events: none;
+  user-select: none;
+}
+
+.ws-print-area {
+  position: absolute;
+  left: 50%; top: 50%;
+  width: 50%; height: 45%;
+  border: 2px dashed #232b2b;
+  border-radius: 6px;
+  box-shadow: 0 0 0 2px #fff5;
+  transform: translate(-50%, -50%);
+  z-index: 3;
+  background: none;
+  pointer-events: auto;
+}
+.ws-print-area:focus { outline: 2px solid var(--ws-accent); }
+
+.ws-size-selector {
+  display: flex; gap: 1rem; margin: 1rem 0;
+}
+.ws-size-btn {
+  border: 2px solid var(--ws-accent); background: #fff;
+  color: var(--ws-accent); border-radius: 18px; font-size: 1rem; padding: .4rem 1.2rem;
+  cursor: pointer; font-weight: 600;
+  transition: background .2s, color .2s;
+}
+.ws-size-btn.active,
+.ws-size-btn:focus { background: var(--ws-accent); color: #fff; outline: none; }
+
+/* TOOLBAR MOBILE */
+.ws-mobile-toolbar {
+  display: flex; gap: 0.6rem; position: fixed; bottom: 0; left: 0; width: 100vw;
+  background: var(--ws-main); box-shadow: 0 -2px 16px #0002;
+  padding: .5rem 0; overflow-x: auto; z-index: 99;
+  justify-content: center;
+}
+.ws-toolbar-btn {
+  font-size: 2.1rem; background: none; border: none; margin: 0 0.4rem; color: var(--ws-btn);
+  border-radius: 10px; width: 48px; height: 48px; cursor: pointer; outline: none;
+  display: flex; align-items: center; justify-content: center;
+  transition: background .2s, color .2s;
+}
+.ws-toolbar-btn:focus, .ws-toolbar-btn.active { background: var(--ws-accent); color: #fff; }
+
+/* Hide toolbar on desktop */
+@media (min-width: 900px) {
+  .ws-mobile-toolbar { display: none !important; }
+}
+
+/* Panels contextuels, slide in/out */
+.ws-panel {
+  display: none; /* JS: display: flex ou block si actif */
+  position: fixed; top: 0; right: 0; height: 100vh; width: 92vw; max-width: 360px;
+  background: #fff; z-index: 199; box-shadow: -4px 0 24px #0002;
+  flex-direction: column; padding: 2rem 1.4rem;
+  overflow-y: auto;
+  transition: transform .35s cubic-bezier(.6,0,.6,1), opacity .18s;
+  transform: translateX(100%);
+  opacity: 0;
+}
+.ws-panel.active {
+  display: flex;
+  transform: translateX(0);
+  opacity: 1;
+}
+
+/* Adaptations desktop : preview plus grand, centré */
+@media (min-width: 900px) {
+  .ws-main { flex-direction: row; }
+  .ws-design-area { flex: 1; align-items: center; }
+  .ws-product-preview {
+    max-width: 640px; max-height: 92vh; width: 48vw; height: 72vh;
+  }
+  .ws-panel { left: 70px; right: auto; width: 340px; }
+}
+
+/* Handles, exemple (injecté par JS) */
+.ws-handle {
+  position: absolute;
+  width: 32px;
+  height: 32px;
+  background: #02b7f0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 1.4rem;
+  box-shadow: var(--ws-shadow);
+  cursor: pointer;
+}
+

--- a/assets/js/winshirt-nextgen.js
+++ b/assets/js/winshirt-nextgen.js
@@ -1,0 +1,59 @@
+(function(){
+  function initPanels() {
+    document.querySelectorAll('.ws-toolbar-btn, .ws-tab-btn').forEach(btn => {
+      btn.addEventListener('click', function () {
+        const tab = btn.dataset.tab;
+        document.querySelectorAll('.ws-panel').forEach(panel => {
+          if (panel.dataset.panel === tab) {
+            panel.classList.add('active');
+          } else {
+            panel.classList.remove('active');
+          }
+        });
+        document.querySelectorAll('.ws-toolbar-btn, .ws-tab-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+      });
+    });
+
+    document.addEventListener('click', function (e) {
+      document.querySelectorAll('.ws-panel.active').forEach(panel => {
+        if (!panel.contains(e.target) && !e.target.classList.contains('ws-toolbar-btn')) {
+          panel.classList.remove('active');
+          document.querySelectorAll('.ws-toolbar-btn, .ws-tab-btn').forEach(b => b.classList.remove('active'));
+        }
+      });
+    });
+  }
+
+  function injectHandles(printArea) {
+    const handleNames = ['close', 'rotate', 'resize', 'scale'];
+    const handleIcons = ['✖', '⟳', '⤢', '↔'];
+    handleNames.forEach((name, idx) => {
+      const h = document.createElement('button');
+      h.className = 'ws-handle ws-handle-' + name;
+      h.type = 'button';
+      h.setAttribute('aria-label', name);
+      h.textContent = handleIcons[idx];
+      printArea.appendChild(h);
+      // TODO: add manipulation events
+    });
+  }
+
+  function initHelp() {
+    if (!localStorage.getItem('ws-help-shown')) {
+      alert('Pincez pour zoomer, glissez pour déplacer, tapotez pour éditer !');
+      localStorage.setItem('ws-help-shown', '1');
+    }
+  }
+
+  function init() {
+    const printArea = document.querySelector('.ws-print-area');
+    if (printArea) {
+      injectHandles(printArea);
+    }
+    initPanels();
+    initHelp();
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/includes/init.php
+++ b/includes/init.php
@@ -7,7 +7,8 @@ add_action('wp_enqueue_scripts', function () {
     $needs_assets = is_product();
     if ( ! $needs_assets && isset( $post->post_content ) ) {
         $needs_assets = has_shortcode( $post->post_content, 'product_page' ) ||
-            has_shortcode( $post->post_content, 'winshirt_customizer' );
+            has_shortcode( $post->post_content, 'winshirt_customizer' ) ||
+            has_shortcode( $post->post_content, 'winshirt_nextgen' );
     }
     if ( ! $needs_assets && function_exists( 'is_account_page' ) && is_account_page() && is_wc_endpoint_url( 'mes-personnalisations' ) ) {
         $needs_assets = true;
@@ -24,11 +25,13 @@ add_action('wp_enqueue_scripts', function () {
         wp_enqueue_style('winshirt-theme', WINSHIRT_URL . 'assets/css/winshirt-theme.css', [], '1.0');
         wp_enqueue_style('winshirt-mockups', WINSHIRT_URL . 'assets/css/winshirt-mockups.css', [], '1.0');
         wp_enqueue_style('winshirt-customizer-page', WINSHIRT_URL . 'assets/css/winshirt-customizer-page.css', [], '1.0');
+        wp_enqueue_style('winshirt-nextgen', WINSHIRT_URL . 'assets/css/winshirt-nextgen.css', [], '1.0');
 
         wp_enqueue_script('winshirt-touch', WINSHIRT_URL . 'assets/js/jquery.ui.touch-punch.min.js', ['jquery', 'jquery-ui-mouse'], '0.2.3', true);
         wp_enqueue_script('html2canvas', 'https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js', [], '1.4.1', true);
         wp_enqueue_script('qrious', 'https://cdnjs.cloudflare.com/ajax/libs/qrious/4.0.2/qrious.min.js', [], '4.0.2', true);
         wp_enqueue_script('winshirt-modal', WINSHIRT_URL . 'assets/js/winshirt-modal.js', ['jquery', 'jquery-ui-draggable', 'jquery-ui-resizable', 'winshirt-touch', 'html2canvas', 'qrious'], '1.0', true);
+        wp_enqueue_script('winshirt-nextgen', WINSHIRT_URL . 'assets/js/winshirt-nextgen.js', [], '1.0', true);
         wp_localize_script('winshirt-modal', 'winshirtAjax', [
             'url'      => admin_url('admin-ajax.php'),
             'rest'     => esc_url_raw(rest_url('winshirt/v1/')),
@@ -217,6 +220,17 @@ function winshirt_customizer_shortcode() {
     return ob_get_clean();
 }
 add_shortcode( 'winshirt_customizer', 'winshirt_customizer_shortcode' );
+
+/**
+ * Display the Next-Gen customizer layout.
+ * Usage: [winshirt_nextgen]
+ */
+function winshirt_nextgen_shortcode() {
+    ob_start();
+    include WINSHIRT_PATH . 'templates/nextgen/page-nextgen.php';
+    return ob_get_clean();
+}
+add_shortcode( 'winshirt_nextgen', 'winshirt_nextgen_shortcode' );
 
 add_filter( 'the_content', 'winshirt_replace_customizer_page' );
 function winshirt_replace_customizer_page( $content ) {

--- a/templates/nextgen/page-nextgen.php
+++ b/templates/nextgen/page-nextgen.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * WinShirt Next-Gen customizer template
+ */
+?>
+
+<!-- PAGE WINSHIRT DÉDIÉE PERSONNALISATION (Lumise-like) -->
+<div class="ws-configurator">
+
+  <!-- HEADER -->
+  <header class="ws-header">
+    <div class="ws-logo">WinShirt</div>
+    <nav class="ws-nav">
+      <button class="ws-nav-btn" aria-label="Retour">←</button>
+      <button class="ws-nav-btn" aria-label="Annuler">⟲</button>
+      <button class="ws-nav-btn" aria-label="Rétablir">⟳</button>
+      <button class="ws-nav-btn" aria-label="Sauvegarder">💾</button>
+    </nav>
+  </header>
+
+  <!-- CONTENU PRINCIPAL -->
+  <main class="ws-main">
+    <!-- SIDEBAR (desktop uniquement) -->
+    <aside class="ws-sidebar">
+      <button class="ws-tab-btn active" data-tab="product">🛍 Produit</button>
+      <button class="ws-tab-btn" data-tab="images">🖼 Images</button>
+      <button class="ws-tab-btn" data-tab="text">✏️ Texte</button>
+      <button class="ws-tab-btn" data-tab="layers">⧉ Calques</button>
+      <button class="ws-tab-btn" data-tab="cliparts">💖 Cliparts</button>
+    </aside>
+    <!-- ZONE DE DESIGN PRINCIPALE -->
+    <section class="ws-design-area">
+      <div class="ws-face-switcher">
+        <button class="ws-face-btn active">Recto</button>
+        <button class="ws-face-btn">Verso</button>
+      </div>
+      <div class="ws-product-preview">
+        <img src="/mockups/tshirt.png" alt="Mockup produit" class="ws-mockup-img" />
+        <div class="ws-print-area" tabindex="0" aria-label="Zone d'impression"></div>
+      </div>
+      <div class="ws-size-selector">
+        <button class="ws-size-btn active">A4</button>
+        <button class="ws-size-btn">A3</button>
+        <button class="ws-size-btn">Coeur</button>
+      </div>
+    </section>
+    <aside class="ws-rightbar"></aside>
+  </main>
+
+  <!-- TOOLBAR MOBILE (scrollable horizontal) -->
+  <nav class="ws-mobile-toolbar">
+    <button class="ws-toolbar-btn" data-tab="product">🛍</button>
+    <button class="ws-toolbar-btn" data-tab="images">🖼</button>
+    <button class="ws-toolbar-btn" data-tab="text">✏️</button>
+    <button class="ws-toolbar-btn" data-tab="layers">⧉</button>
+    <button class="ws-toolbar-btn" data-tab="cliparts">💖</button>
+    <button class="ws-toolbar-btn" data-tab="ai">🤖</button>
+    <button class="ws-toolbar-btn" data-tab="qrcode">#️⃣</button>
+  </nav>
+
+  <!-- PANELS CONTEXTUELS -->
+  <section class="ws-panel" data-panel="product"></section>
+  <section class="ws-panel" data-panel="images"></section>
+  <section class="ws-panel" data-panel="text"></section>
+  <section class="ws-panel" data-panel="layers"></section>
+  <section class="ws-panel" data-panel="cliparts"></section>
+  <section class="ws-panel" data-panel="ai"></section>
+  <section class="ws-panel" data-panel="qrcode"></section>
+</div>


### PR DESCRIPTION
## Summary
- add new Next-Gen customizer template
- load new styles and scripts via init hooks
- expose `[winshirt_nextgen]` shortcode
- provide dedicated CSS and JS modules

## Testing
- `php -l templates/nextgen/page-nextgen.php`
- `php -l includes/init.php`
- `find . -name '*.php' -print0 | xargs -0 -I{} php -l {}`
- `node --check assets/js/winshirt-nextgen.js`


------
https://chatgpt.com/codex/tasks/task_e_6884aa4086f48329b246030e21feb832