### PR TITLE
Fix NextGen mockup switching

### DIFF
--- a/assets/css/winshirt-nextgen.css
+++ b/assets/css/winshirt-nextgen.css
@@ -103,9 +103,9 @@ body {
 .ws-mockup-img {
   display: block;
   width: 100%;
-  height: auto;
-  max-height: 74vh;
+  height: 100%;
   object-fit: contain;
+  object-position: center;
   pointer-events: none;
   user-select: none;
 }

--- a/assets/js/winshirt-nextgen.js
+++ b/assets/js/winshirt-nextgen.js
@@ -46,12 +46,27 @@
     }
   }
 
+  function initFaceSwitcher() {
+    const img = document.querySelector('.ws-mockup-img');
+    const faceBtns = document.querySelectorAll('.ws-face-btn');
+    if (!img || !faceBtns.length) return;
+    faceBtns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        faceBtns.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const isBack = btn.textContent.trim().toLowerCase() === 'verso';
+        img.src = isBack ? img.dataset.back : img.dataset.front;
+      });
+    });
+  }
+
   function init() {
     const printArea = document.querySelector('.ws-print-area');
     if (printArea) {
       injectHandles(printArea);
     }
     initPanels();
+    initFaceSwitcher();
     initHelp();
   }
 

--- a/templates/nextgen/page-nextgen.php
+++ b/templates/nextgen/page-nextgen.php
@@ -2,6 +2,20 @@
 /**
  * WinShirt Next-Gen customizer template
  */
+
+$vars = $GLOBALS['winshirt_customizer_vars'] ?? [];
+$front_url = $vars['default_front'] ?? '';
+$back_url  = $vars['default_back'] ?? '';
+
+$default_front = 'https://winshirt.fr/wp-content/uploads/2025/06/White-Tshirt-Recto.png';
+$default_back  = 'https://winshirt.fr/wp-content/uploads/2025/06/White-Tshirt-Verso.png';
+
+if ( ! $front_url ) {
+  $front_url = $default_front;
+}
+if ( ! $back_url ) {
+  $back_url = $default_back;
+}
 ?>
 
 <!-- PAGE WINSHIRT DÉDIÉE PERSONNALISATION (Lumise-like) -->
@@ -35,7 +49,7 @@
         <button class="ws-face-btn">Verso</button>
       </div>
       <div class="ws-product-preview">
-        <img src="<?php echo esc_url( WINSHIRT_URL . 'assets/img/tshirt.svg' ); ?>" alt="Mockup produit" class="ws-mockup-img" />
+        <img src="<?php echo esc_url( $front_url ); ?>" data-front="<?php echo esc_url( $front_url ); ?>" data-back="<?php echo esc_url( $back_url ); ?>" alt="Mockup produit" class="ws-mockup-img" />
         <div class="ws-print-area" tabindex="0" aria-label="Zone d'impression"></div>
       </div>
       <div class="ws-size-selector">


### PR DESCRIPTION
## Summary
- pull selected mockup URLs from admin settings
- allow front/back switching of mockup image
- ensure mockup is centered and contained in preview

## Testing
- `php -l templates/nextgen/page-nextgen.php`
- `node -c assets/js/winshirt-nextgen.js`


------
https://chatgpt.com/codex/tasks/task_e_68867d1aa820832994d5fa78ab588b59